### PR TITLE
Fix GitHub Actions CI dependency installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,9 @@ jobs:
         targets: wasm32-unknown-unknown
         
     - name: Install wasm-pack
-      run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      uses: jetli/wasm-pack-action@v0.4.0
+      with:
+        version: 'latest'
       
     - name: Cache Bun dependencies
       uses: actions/cache@v4
@@ -46,7 +48,7 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
         
     - name: Install dependencies
-      run: bun install
+      run: bun install --no-save
       
     - name: Build WASM
       run: bun run build:wasm


### PR DESCRIPTION
This PR addresses dependency installation failures in the CI/CD pipeline by:

1. Using the jetli/wasm-pack-action instead of manually installing wasm-pack
2. Adding --no-save flag to bun install to prevent lockfile modifications during CI

These changes should improve stability of the GitHub Actions workflow.