### PR TITLE
Fix Bun installation issues in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup Bun
       uses: oven-sh/setup-bun@v1
       with:
-        bun-version: latest
+        bun-version: 1.2.15
         
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@stable
@@ -33,8 +33,10 @@ jobs:
     - name: Cache Bun dependencies
       uses: actions/cache@v4
       with:
-        path: ~/.bun
-        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+        path: |
+          ~/.bun
+          node_modules
+        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
         restore-keys: |
           ${{ runner.os }}-bun-
           
@@ -48,7 +50,7 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
         
     - name: Install dependencies
-      run: bun install --no-save
+      run: bun install --frozen-lockfile
       
     - name: Build WASM
       run: bun run build:wasm


### PR DESCRIPTION
This PR resolves the Bun package installation issues in the CI/CD pipeline by:

1. Using a fixed Bun version (1.2.15) instead of latest
2. Using --frozen-lockfile flag instead of --no-save
3. Improving cache configuration by including node_modules directory
4. Using the correct bun.lock file for cache key instead of bun.lockb

These changes should stabilize the CI build process by ensuring consistent Bun execution.