### PR TITLE
Fix Bun configuration shell setting

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -14,7 +14,7 @@ optional = true
 
 [run]
 # Enable shell expansion for scripts
-shell = "zsh"
+shell = "system"
 silent = false
 
 [test]


### PR DESCRIPTION
This PR fixes the CI/CD build failure related to the bunfig.toml configuration:

The error was:


Changes:
- Changed the shell setting from 'zsh' to 'system' which is one of the two values supported by Bun