### PR TITLE
feat(cli): --curve ed25519 in serve + one-shot (independently-verifiable demo)

### DIFF
--- a/apps/cli-node/src/main.rs
+++ b/apps/cli-node/src/main.rs
@@ -73,6 +73,12 @@ struct OneShot {
     room: Option<String>,
     #[arg(long, default_value_t = 90)]
     timeout: u64,
+    /// Ciphersuite: secp256k1 (default; Ethereum/Bitcoin) or ed25519 (Solana).
+    /// ed25519 yields a standard RFC-8032 signature that ANY off-the-shelf
+    /// verifier (and Solana) can check — ideal for an independently-checkable
+    /// demo. All participants of one ceremony must use the same curve.
+    #[arg(long, default_value = "secp256k1")]
+    curve: String,
     #[arg(long, default_value = "")]
     log_level: String,
 }
@@ -150,6 +156,7 @@ impl OneShot {
             keystore_path: expand_tilde(&self.keystore),
             signal_url: with_room(&self.signal_server, self.room.as_deref()),
             timeout_secs: self.timeout,
+            curve: self.curve.clone(),
         }
     }
 }
@@ -212,7 +219,8 @@ struct ServeArgs {
     /// participants of a ceremony must use the same strong id (e.g. a UUID).
     #[arg(long)]
     room: Option<String>,
-    /// Ciphersuite (P1: secp256k1 only).
+    /// Ciphersuite: secp256k1 (default) or ed25519 (Solana; RFC-8032
+    /// signatures any standard verifier accepts). Same curve on all nodes.
     #[arg(long, default_value = "secp256k1")]
     curve: String,
     /// tracing filter (stderr).

--- a/apps/cli-node/src/oneshot.rs
+++ b/apps/cli-node/src/oneshot.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
-use tui_node::elm::headless::spawn_secp256k1;
+use tui_node::elm::headless::{spawn_ed25519, spawn_secp256k1};
 use tui_node::elm::model::{WalletConfig, WalletMode};
 use tui_node::elm::{Message, Model};
 
@@ -21,23 +21,37 @@ pub struct OneShotOpts {
     pub keystore_path: String,
     pub signal_url: String,
     pub timeout_secs: u64,
+    /// Ciphersuite: "secp256k1" (default) or "ed25519". ed25519 produces a
+    /// standard RFC-8032 signature that any off-the-shelf verifier (and Solana)
+    /// can check — the runner ciphersuite is fixed at spawn.
+    pub curve: String,
 }
 
 /// Spawn a runner whose events stream to the returned receiver.
 fn start(opts: &OneShotOpts) -> (UnboundedSender<Message>, UnboundedReceiver<CliEvent>) {
     let bridge = Arc::new(Mutex::new(Bridge::new()));
     let (ev_tx, ev_rx) = unbounded_channel::<CliEvent>();
-    let tx = spawn_secp256k1(
-        opts.device_id.clone(),
-        opts.keystore_path.clone(),
-        opts.signal_url.clone(),
-        move |model: &Model, msg: Option<&Message>| {
-            let events = bridge.lock().unwrap().on_sync(model, msg);
-            for e in events {
-                let _ = ev_tx.send(e);
-            }
-        },
-    );
+    let cb = move |model: &Model, msg: Option<&Message>| {
+        let events = bridge.lock().unwrap().on_sync(model, msg);
+        for e in events {
+            let _ = ev_tx.send(e);
+        }
+    };
+    let tx = if opts.curve == "ed25519" {
+        spawn_ed25519(
+            opts.device_id.clone(),
+            opts.keystore_path.clone(),
+            opts.signal_url.clone(),
+            cb,
+        )
+    } else {
+        spawn_secp256k1(
+            opts.device_id.clone(),
+            opts.keystore_path.clone(),
+            opts.signal_url.clone(),
+            cb,
+        )
+    };
     (tx, ev_rx)
 }
 

--- a/apps/cli-node/src/serve.rs
+++ b/apps/cli-node/src/serve.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, Mutex};
 
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
-use tui_node::elm::headless::spawn_secp256k1;
+use tui_node::elm::headless::{spawn_ed25519, spawn_secp256k1};
 use tui_node::elm::model::{WalletConfig, WalletMode};
 use tui_node::elm::{Message, Model};
 
@@ -26,7 +26,8 @@ pub struct ServeOpts {
     pub device_id: String,
     pub keystore_path: String,
     pub signal_url: String,
-    /// secp256k1 only for now (the runner ciphersuite is fixed at spawn).
+    /// "secp256k1" (default) or "ed25519" — the runner ciphersuite, fixed at
+    /// spawn. ed25519 produces standard RFC-8032 signatures.
     pub curve: String,
     /// Auto-approval policy for incoming signing requests (disabled unless
     /// the operator opts in). Shared so the runner callback can consume it.
@@ -80,11 +81,7 @@ pub async fn serve(opts: ServeOpts) -> anyhow::Result<()> {
     let approve_sender_cb = approve_sender.clone();
     let policy = opts.auto_approve.clone();
     let approve_pw = opts.approve_password.clone();
-    let runner_tx = spawn_secp256k1(
-        opts.device_id.clone(),
-        opts.keystore_path.clone(),
-        opts.signal_url.clone(),
-        move |model: &Model, msg: Option<&Message>| {
+    let cb = move |model: &Model, msg: Option<&Message>| {
             let mut b = bridge_for_sync.lock().unwrap();
             let events = b.on_sync(model, msg);
             *snapshot_for_sync.lock().unwrap() = b.snapshot(model);
@@ -129,8 +126,23 @@ pub async fn serve(opts: ServeOpts) -> anyhow::Result<()> {
                 }
                 let _ = out_for_sync.send(ev);
             }
-        },
-    );
+        }
+    ;
+    let runner_tx = if opts.curve == "ed25519" {
+        spawn_ed25519(
+            opts.device_id.clone(),
+            opts.keystore_path.clone(),
+            opts.signal_url.clone(),
+            cb,
+        )
+    } else {
+        spawn_secp256k1(
+            opts.device_id.clone(),
+            opts.keystore_path.clone(),
+            opts.signal_url.clone(),
+            cb,
+        )
+    };
     let _ = approve_sender.set(runner_tx.clone());
 
     // --- input loop: stdin JSONL → runner / snapshot replies ---

--- a/docs/LIVE_MPC_DEMO.md
+++ b/docs/LIVE_MPC_DEMO.md
@@ -1,0 +1,305 @@
+# Live MPC Demo — Raw CLI, Independently Verifiable
+
+**Audience:** the person running the demo, and the (skeptical) investors watching.
+**Goal:** prove, in front of a sceptic, that this is **real threshold cryptography across
+real, separate machines** — not a script pretending. Every command is raw and visible;
+the final signature is verified by a **tool that is not ours** (Node.js / Python / OpenSSL),
+and the public key is a **real Solana address**.
+
+> **The one idea that makes this unfakeable:** we run the ceremony on the **ed25519**
+> curve. A FROST‑ed25519 threshold signature is a *completely standard* RFC‑8032
+> Ed25519 signature. So the investor can verify it with their own laptop's crypto
+> library, with zero knowledge of our code. If a universally‑trusted library says
+> "valid", it's valid. (On secp256k1 our signature is RFC‑9591, which no off‑the‑shelf
+> tool checks — so we deliberately demo on ed25519.)
+
+---
+
+## 0. What this demo proves (and the sceptic's objections it answers)
+
+| Investor's doubt | How the demo answers it |
+|---|---|
+| "It's one program faking multiple parties." | **Three separate processes** (ideally three laptops), each with its **own keystore file**, each printing its result independently. |
+| "Your tool says it's valid — maybe your tool lies." | The signature is verified by **Node.js / Python / OpenSSL built‑in crypto** — code we didn't write — and the key is a **real Solana address**. |
+| "Maybe one machine secretly holds the whole key." | **No machine can sign alone.** With a 2‑of‑3 wallet, one device trying to sign just **times out**. Two must cooperate. (Live proof in §6.) |
+| "It's pre‑recorded / canned." | The investor **picks the message** to sign, on the spot. The signature changes; it still verifies. |
+| "The key was generated once and hard‑coded." | A **fresh wallet is created live** via distributed key generation (DKG); the key is different every run and depends on all three machines' randomness. |
+
+---
+
+## 1. Roles & prerequisites
+
+- **Three participants** — call them **alice**, **bob**, **carol**. Ideally three
+  separate laptops; three terminals on one machine also works (less convincing, same crypto).
+- Each machine needs the `mpc-wallet-cli` binary:
+  ```bash
+  cargo build --release -p mpc-wallet-cli
+  # binary: ./target/release/mpc-wallet-cli
+  ```
+- Internet access (the demo uses the hosted signal server `wss://panda.qzz.io`).
+  - *No internet?* See §7 — one laptop runs the server on the LAN.
+- One verifier tool on the investor's machine: **Node.js** (easiest), or Python with
+  `cryptography`/`PyNaCl`, or `openssl`. All shown in §5.
+
+> **Protocol transport.** Each node runs `mpc-wallet-cli serve`, which speaks **newline‑
+> delimited JSON**: you type a command object on stdin, it prints event objects on stdout.
+> Investors literally see the wire protocol — nothing hidden.
+
+---
+
+## 2. One‑time setup: the shared room
+
+The hosted server is multi‑tenant. Every participant of one wallet must use the **same
+strong room id** (≥16 chars). One person generates it and shares the exact value:
+
+```bash
+ROOM=$(uuidgen | tr -d -)      # e.g. 7f3a9c2e4b1d4e8a9c2f001122334455
+echo "$ROOM"                   # send this exact string to bob and carol
+```
+
+Pick a shared password for the demo too (e.g. `demo`). In a real deployment each device
+has its own; for the demo a shared one keeps it simple. **Never type a real password on a
+slide.**
+
+---
+
+## 3. Start the three nodes
+
+Each person runs **one** command (substitute their name). Keep these terminals open and
+visible.
+
+```bash
+# alice
+./target/release/mpc-wallet-cli serve --curve ed25519 \
+  --device-id alice --keystore ~/.frost_alice \
+  --signal-server wss://panda.qzz.io --room "$ROOM"
+
+# bob
+./target/release/mpc-wallet-cli serve --curve ed25519 \
+  --device-id bob --keystore ~/.frost_bob \
+  --signal-server wss://panda.qzz.io --room "$ROOM"
+
+# carol
+./target/release/mpc-wallet-cli serve --curve ed25519 \
+  --device-id carol --keystore ~/.frost_carol \
+  --signal-server wss://panda.qzz.io --room "$ROOM"
+```
+
+Each prints:
+```json
+{"event":"ready","protocol":1,"device_id":"alice","curve":"ed25519"}
+{"event":"connection","connected":true}
+```
+
+> **Device ids must be unique.** Two nodes with the same `--device-id` collide on the
+> server and the mesh won't form. alice / bob / carol — all different.
+
+---
+
+## 4. Create the wallet, then sign (the live ceremony)
+
+Everything below is typed into a node's terminal (its stdin). Type the JSON and press Enter.
+
+### 4a. alice creates a 2‑of‑3 wallet (distributed key generation)
+
+In **alice's** terminal:
+```json
+{"cmd":"create_wallet","threshold":2,"total":3,"password":"demo"}
+```
+
+alice immediately prints the session id — **read it out**:
+```json
+{"event":"session_announced","session_id":"dkg_8f1c…"}
+```
+
+### 4b. bob and carol join that session
+
+In **bob's** and **carol's** terminals (use the id alice just announced):
+```json
+{"cmd":"join_session","session_id":"dkg_8f1c…","password":"demo"}
+```
+
+After a few seconds, **all three** terminals independently print the same result:
+```json
+{"event":"dkg_complete","wallet_id":"…","address":"<Solana base58 address>","group_public_key":"<64 hex chars>"}
+```
+
+> 🎤 **Talking point:** "Three separate machines just generated a shared wallet. None of
+> them holds the whole private key — each holds one *share*. Notice all three print the
+> **same** public key and the **same** Solana address, independently."
+>
+> Show the investor the three keystore files exist and differ:
+> ```bash
+> ls -la ~/.frost_alice ~/.frost_bob ~/.frost_carol   # three separate shares on disk
+> ```
+
+### 4c. Sign a message the investor chooses
+
+Ask the investor for a phrase. Put it in **alice's** terminal (`message` = their words):
+```json
+{"cmd":"sign","wallet_id":"<wallet_id from dkg_complete>","message":"we closed the round","encoding":"utf8","password":"demo"}
+```
+
+**bob** sees an approval request and consents (use the `sign_…` id bob prints):
+```json
+{"event":"signing_request","session_id":"sign_3a2e…","wallet":"…"}
+```
+```json
+{"cmd":"approve_signing","session_id":"sign_3a2e…","password":"demo"}
+```
+
+alice prints the finished signature:
+```json
+{"event":"signature_complete","signature":"0x<128 hex chars>","message_hash":"…"}
+```
+
+> 🎤 **Talking point:** "Two of the three devices just co‑signed the investor's exact
+> message. Let's prove it's real — with a tool none of us wrote."
+
+---
+
+## 5. The money shot: independent verification
+
+Hand the investor **three values** from the run:
+
+- **GK** — `group_public_key` (64 hex chars) from `dkg_complete`
+- **SIG** — `signature` from `signature_complete`, **drop the leading `0x`** (128 hex chars)
+- **MSG** — the exact message string you signed (e.g. `we closed the round`)
+
+The investor runs **any one** of these on **their own machine**:
+
+### Node.js (built‑in `crypto`, no install)
+```bash
+node -e '
+const crypto=require("crypto");
+const GK="PASTE_GK", SIG="PASTE_SIG_NO_0x", MSG="we closed the round";
+const der=Buffer.concat([Buffer.from("302a300506032b6570032100","hex"),Buffer.from(GK,"hex")]);
+const pub=crypto.createPublicKey({key:der,format:"der",type:"spki"});
+console.log("VERIFIED:", crypto.verify(null, Buffer.from(MSG), pub, Buffer.from(SIG,"hex")));
+'
+# → VERIFIED: true
+```
+
+### Python (`cryptography`)
+```bash
+python3 -c '
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+GK="PASTE_GK"; SIG="PASTE_SIG_NO_0x"; MSG=b"we closed the round"
+Ed25519PublicKey.from_public_bytes(bytes.fromhex(GK)).verify(bytes.fromhex(SIG), MSG)
+print("VERIFIED: True")   # raises + prints nothing if invalid
+'
+```
+
+### Python (`PyNaCl`)
+```bash
+python3 -c '
+from nacl.signing import VerifyKey
+GK="PASTE_GK"; SIG="PASTE_SIG_NO_0x"; MSG=b"we closed the round"
+VerifyKey(bytes.fromhex(GK)).verify(MSG, bytes.fromhex(SIG)); print("VERIFIED: True")
+'
+```
+
+### OpenSSL
+```bash
+# portable hex→binary helper (works without xxd):
+hex2bin(){ python3 -c "import sys,binascii;open(sys.argv[2],'wb').write(binascii.unhexlify(sys.argv[1]))" "$1" "$2"; }
+
+hex2bin "302a300506032b6570032100PASTE_GK" pub.der     # 12-byte SPKI prefix + key
+openssl pkey -pubin -inform DER -in pub.der -out pub.pem
+printf '%s' "we closed the round" > msg.bin
+hex2bin "PASTE_SIG_NO_0x" sig.bin
+openssl pkeyutl -verify -pubin -inkey pub.pem -rawin -in msg.bin -sigfile sig.bin
+# → Signature Verified Successfully
+```
+
+### Bonus: it's a real Solana address
+The `address` from `dkg_complete` is the base58 of that same 32‑byte key — a valid Solana
+account. Paste it into <https://explorer.solana.com> to show it's a real, well‑formed
+account this wallet controls.
+
+> 🎤 **Closing line:** "Your own crypto library — not ours — just confirmed that a
+> signature, over the message *you* chose, is valid under a key that is a real Solana
+> address, produced by two of three independent machines that each held only a fragment.
+> That is threshold MPC, live."
+
+---
+
+## 6. Optional but powerful: "one device cannot sign alone"
+
+This is the most visceral proof that the key is genuinely split.
+
+1. In **alice's** terminal, start a sign **but have nobody approve**:
+   ```json
+   {"cmd":"sign","wallet_id":"…","message":"alice alone","encoding":"utf8","password":"demo"}
+   ```
+2. Wait. With threshold 2 and only alice participating, the ceremony **cannot complete**
+   — it times out with no signature.
+3. Now repeat with bob approving → it completes.
+
+> 🎤 "One machine, by itself, is powerless. The threshold is enforced by mathematics, not
+> by policy."
+
+---
+
+## 7. Fallback ladder (if the network misbehaves)
+
+Have these ready; you should never be stuck.
+
+| Rung | When | What to do |
+|---|---|---|
+| **0. Live** | normal | `wss://panda.qzz.io` + a shared `--room` (the steps above). |
+| **1. LAN server** | internet flaky | One laptop runs the server: `MPC_SIGNAL_BIND=0.0.0.0:9000 cargo run --release -p webrtc-signal-server`. Everyone uses `--signal-server ws://<that-laptop-LAN-ip>:9000` (a local server needs **no** room). Same demo, no internet. |
+| **2. Nuclear (cannot fail)** | everything is on fire | On one machine: `./target/release/mpc-wallet-cli simulate --nodes 3 --threshold 2 --curve ed25519 --sign "we closed the round"`. Full DKG + signing + a verifiable signature in ~3s, self‑contained. Then verify with §5. Less impressive (one machine) but the **crypto is identical and still independently verifiable**. |
+
+**Pre‑flight (run 10 minutes before, on each machine):**
+```bash
+SIGNAL=wss://panda.qzz.io scripts/demo/preflight.sh
+# proves the local crypto stack AND a real ceremony through the live server. Green = go.
+```
+
+---
+
+## 8. Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `WebSocket … 400` / connection rejected | Missing or weak `--room` (the hosted server requires ≥16 chars). Generate with `uuidgen \| tr -d -`; everyone uses the **same** value. |
+| "Waiting for participants" forever | Not everyone is on the **same room** and **same server**; or duplicate `--device-id`. Check all three. |
+| bob/carol never see the session | They connected after alice announced — they just need to send `join_session` with the id alice printed. (Joins also work if they connect late.) |
+| Verifier says **false** | Wrong `MSG` bytes (must be the **exact** message signed), or the `0x` wasn't stripped from `SIG`, or GK/SIG were transcribed with a typo. Re‑copy. |
+| Signature verifies but address looks odd | The `address` is base58 (Solana); the `group_public_key` is hex. They're the same key in two encodings. |
+
+---
+
+## 9. Under the hood (for the technical investor who asks)
+
+- **DKG (key generation):** FROST distributed key generation, Pedersen variant — **no
+  trusted dealer**. Each device contributes randomness; the private key is never
+  assembled anywhere. Each device ends with a *share*; the group public key is public.
+- **Signing:** FROST threshold Schnorr. `t` of `n` devices each produce a partial
+  signature; these aggregate into **one ordinary signature** that verifies under the group
+  key with a standard verifier. No device ever sees another's share.
+- **Curve:** ed25519 (RFC 8032). The group key is a normal Ed25519 public key (a Solana
+  address); the signature is a normal Ed25519 signature — hence the independent
+  verification in §5. The same software also runs secp256k1 (Ethereum/Bitcoin family); we
+  demo ed25519 specifically because it is verifiable with off‑the‑shelf tools.
+- **Transport:** a signal server for discovery + WebRTC for the encrypted peer‑to‑peer
+  mesh the shares travel over. The signal server never sees key material.
+- **Recovery / custody note:** because there's no dealer, the seed of one device alone
+  cannot reconstruct its share — the encrypted keystore per device is the backup unit.
+  (See `docs/MULTI_CURVE_DERIVATION.md`.)
+
+---
+
+## 10. Quick reference card (print this)
+
+```
+SETUP   ROOM=$(uuidgen | tr -d -)               # share this exact value
+NODE    mpc-wallet-cli serve --curve ed25519 --device-id <name> \
+        --keystore ~/.frost_<name> --signal-server wss://panda.qzz.io --room "$ROOM"
+CREATE  (alice) {"cmd":"create_wallet","threshold":2,"total":3,"password":"demo"}
+JOIN    (bob,carol) {"cmd":"join_session","session_id":"dkg_…","password":"demo"}
+SIGN    (alice) {"cmd":"sign","wallet_id":"…","message":"<investor's words>","encoding":"utf8","password":"demo"}
+APPROVE (bob)   {"cmd":"approve_signing","session_id":"sign_…","password":"demo"}
+VERIFY  node -e '…'   # §5 — investor runs it; → VERIFIED: true
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,12 @@ workspace member.
 
 ## Contents
 
+- [`LIVE_MPC_DEMO.md`](LIVE_MPC_DEMO.md) — **run the live, independently
+  verifiable MPC demo** for investors: raw `mpc-wallet-cli` commands across
+  three machines (ed25519), with the signature verified by an *external* tool
+  (Node/Python/OpenSSL) and the key shown as a real Solana address. Includes
+  talking points, the "one device can't sign alone" proof, fallbacks, and
+  troubleshooting.
 - [`MONOREPO_ARCHITECTURE.md`](MONOREPO_ARCHITECTURE.md) — workspace
   layout, how the Rust + Bun workspaces fit together, build order.
 - [`MPC_WALLET_TECHNICAL_DOCUMENTATION.md`](MPC_WALLET_TECHNICAL_DOCUMENTATION.md)


### PR DESCRIPTION
`serve` and the one-shot commands hardcoded `spawn_secp256k1`; `--curve` was accepted but ignored. `simulate` already branches on curve — this wires the same dispatch into `serve`/`oneshot`.

**Why:** a FROST-ed25519 threshold signature is a *standard RFC-8032 Ed25519 signature* — any off-the-shelf verifier (Node.js `crypto`, PyNaCl, openssl) and Solana itself verify it against the 32-byte group key. secp256k1 FROST is RFC-9591 (not BIP-340), so nothing off-the-shelf verifies it. ed25519 makes a live demo **independently checkable** by a skeptic.

Verified end to end: 3 separate `serve --curve ed25519` processes through the deployed worker + room → all three agree on one 32-byte group key; a 2-of-3 signature **verifies under Node.js built-in crypto (RFC 8032, not our code)**. 27 cli unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)