### PR TITLE
test(interop): system-Chrome support for the L3c harness (#33 partial)

### DIFF
--- a/apps/browser-extension/tests/interop/fixtures.ts
+++ b/apps/browser-extension/tests/interop/fixtures.ts
@@ -25,12 +25,17 @@ export const test = base.extend<ExtFixtures>({
         `Built extension not found at ${EXT_PATH}. Run \`bun run build\` first.`,
       );
     }
+    // Use a system Chrome when PLAYWRIGHT_CHROME_PATH is set (e.g. Nix/CI where
+    // Playwright's bundled chromium can't resolve system libs); else bundled.
+    const executablePath = process.env.PLAYWRIGHT_CHROME_PATH || undefined;
     const context = await chromium.launchPersistentContext("", {
       headless: false,
+      executablePath,
       args: [
         `--disable-extensions-except=${EXT_PATH}`,
         `--load-extension=${EXT_PATH}`,
         "--no-first-run",
+        "--no-sandbox",
       ],
     });
     await use(context);


### PR DESCRIPTION
Lets the Playwright L3c harness use a system/Nix Chrome via `PLAYWRIGHT_CHROME_PATH` (the bundled chromium can't resolve system libs in some envs, e.g. Nix: `libglib-2.0.so.0`). With this, the harness launches Chrome with the MV3 extension args. **Still open on #33:** in this Nix+Chrome-148 sandbox the unpacked MV3 service worker doesn't activate, so the full ext↔CLI flow couldn't be driven here — needs a standard Chrome-for-Testing/CI env or a real dev machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)