### PR TITLE
feat(frost-core): tested share refresh/resharing engine (#45)

### DIFF
--- a/docs/RECOVERY_AND_RESHARING.md
+++ b/docs/RECOVERY_AND_RESHARING.md
@@ -18,7 +18,8 @@ actually provide. Read with [`MULTI_CURVE_DERIVATION.md`](MULTI_CURVE_DERIVATION
   stays the same**, every share is replaced with a fresh one, and a removed device's old
   share becomes **worthless**.
 - The cryptographic primitive for this **already exists in `frost-core` (`keys::refresh`)**,
-  including a **dealerless** variant matching our no-trusted-dealer model. Wiring it into a
+  including a **dealerless** variant matching our no-trusted-dealer model. The engine is
+  **implemented and tested** (`frost-core/src/resharing.rs`); wiring it into a networked
   one-command client ceremony is the remaining engineering (tracked below).
 - The everyday backup unit remains the **encrypted keystore + password** per device.
 
@@ -28,7 +29,7 @@ actually provide. Read with [`MULTI_CURVE_DERIVATION.md`](MULTI_CURVE_DERIVATION
 
 | Situation (2-of-3 example) | Funds safe? | Can still sign? | What to do |
 |---|:--:|:--:|---|
-| Lose **1** device (keystore gone) | ✅ | ✅ (other 2) | Refresh to a replacement device (§3). |
+| Lose **1** device (keystore gone) | ✅ | ✅ (other 2) | Refresh over the survivors (→ 2-of-2, same address), or restore the lost device from its keystore backup (§3). |
 | Lose **2** devices, no keystore backups | ❌ | ❌ | Below threshold → unrecoverable. Choose `t<n` and back up keystores to avoid this. |
 | **1** device stolen | ✅ | ✅ | Attacker has 1 < 2 shares → can't sign. **Refresh** to rotate that share to worthless (§3, §4). |
 | **t** devices stolen/colluding | ❌ | (attacker can) | This is the threshold assumption being violated. Pick `t` for your trust model. |
@@ -52,28 +53,37 @@ and unlock. Simple, but the password is **unrecoverable by design** — store th
 losing one doesn't lose both.
 
 ### (b) Refresh / resharing — the quorum path (no backup needed)
-A threshold `t` of current holders collaboratively **issue fresh shares**, optionally to a
-**different participant set** (drop a lost/stolen device, add a replacement). Properties:
+A threshold `t` of current holders collaboratively **issue fresh shares**. Properties:
 
 - **Group public key — and therefore your on-chain address — is unchanged.** No funds move,
   no re-funding, no address rotation.
 - **All shares are replaced.** Any share from before the refresh (e.g. on a stolen device)
   **no longer works** with the new set — it can't combine with refreshed shares to sign.
-- **Threshold cannot be lowered** by a refresh (you can't weaken security this way); the
-  participant *set* can change.
+- **Threshold cannot be lowered** by a refresh (you can't weaken security this way).
+- The participant set can **shrink** (remove a device), but a refresh **cannot add a
+  brand-new device that never held a share** — frost-core's refresh requires every
+  refreshing participant to bring its existing `KeyPackage`. Bringing a fresh replacement
+  online is a keystore-restore or a fuller enrollment protocol (see §3).
+
+> Verified in code: `frost-core/src/resharing.rs` proves group-key preservation, that an
+> old share can't combine with refreshed shares, and that a participant can be removed —
+> and that refresh **rejects** a participant with no prior share.
 
 ---
 
 ## 3. Recovery flows (operationally)
 
-**Lost device, quorum survives (2-of-3, lose carol):**
-1. alice + bob (a quorum) run a resharing ceremony for the new set `{alice, bob, dave}`.
-2. dave receives a fresh share; alice & bob get refreshed shares; carol's old share is dead.
-3. The wallet address is identical; the wallet keeps working, now on the new three devices.
+**Stolen/compromised device — proactive rotation (the strong case, fully supported):**
+1. The remaining holders run a refresh; the stolen share is rotated to **worthless** while
+   the address is unchanged. Optionally **remove** the compromised device (refresh over the
+   subset, e.g. 2-of-3 → 2-of-2 over `{alice, bob}`).
 
-**Stolen device (proactive rotation):**
-1. Even before stealing a 2nd device matters, run a refresh over `{alice, bob, dave}`
-   (excluding the stolen carol). The thief's share is now worthless.
+**Lost device, quorum survives (2-of-3, lose carol):**
+- **Keep it simple:** refresh over the survivors `{alice, bob}` → a 2-of-2 wallet, **same
+  address**, carol's old share dead. You're back to a working wallet immediately.
+- **Restore a third device:** bring carol's *replacement* online by **restoring carol's
+  encrypted keystore backup** to it (the everyday path, §2a). A refresh can then rotate all
+  three. *(Adding a never-seen device purely via refresh is not supported — see §2b.)*
 
 **Below threshold, no backups:** unrecoverable — this is the security guarantee, not a bug.
 Mitigate *in advance* by choosing `t < n` and/or keeping encrypted keystore backups.
@@ -95,24 +105,29 @@ refresh_dkg_shares(...)   // each participant: derive its refreshed KeyPackage +
 (A trusted-dealer variant — `compute_refreshing_shares()` + `refresh_share()` — also exists
 for simpler setups.)
 
-This mirrors the existing DKG plumbing almost exactly, so the implementation reuses the
-session/transport machinery already built:
+**The engine is implemented and tested** in `frost-core/src/resharing.rs`:
+`refresh(old_kps, old_pub, new_ids, threshold, …)` runs the three `refresh_dkg_*` steps
+across the (possibly reduced) participant set and returns fresh key packages with the group
+key preserved. Tests prove key-preservation, old-share invalidation, removal, and the
+"can't refresh a shareless participant" guard.
+
+What remains is the **networked client ceremony** around it, which mirrors the existing DKG
+plumbing:
 
 - **Transport & coordination:** identical to DKG — signal-server session announce/join +
   the WebRTC mesh. A new session type `reshare` (alongside `dkg`/`signing`).
-- **Engine:** add a refresh path next to the curve registry / unified DKG, calling the three
-  `refresh_dkg_*` functions instead of `dkg::part1/2/3`. The output share replaces the
-  on-disk keystore; the group key is asserted unchanged.
-- **CLI surface (proposed):** `mpc-wallet-cli reshare --wallet-id <id> --new-set alice,bob,dave`
-  (creator) + `session join` for the others — the same UX shape as `wallet create`.
-- **Safety:** after a successful refresh, securely erase the **old** keystore (the old share
-  must not linger). Verify the new `PublicKeyPackage` equals the old group key before
-  committing the swap.
+- **Client engine:** drive `resharing::refresh` over the mesh (the per-participant round
+  packages instead of the in-process loop). Output share replaces the on-disk keystore.
+- **CLI surface (proposed):** `mpc-wallet-cli reshare --wallet-id <id> --keep alice,bob`
+  (the surviving/retained set) + `session join` for the others — same UX shape as
+  `wallet create`. *(Removing a device = omit it from `--keep`. Adding a fresh device is a
+  separate keystore-restore/enrollment step, not a flag here — see §2b.)*
+- **Safety:** assert the new `PublicKeyPackage` equals the old group key before committing;
+  then securely erase the **old** keystore so the stale share can't linger.
 
-**Status:** primitive available in `frost-core`; the client ceremony (session type, engine
-path, CLI/UX, old-share erase) is **not yet implemented**. This is the one‑to‑few‑PR gap to
-turn "your funds are recoverable" from a property into a button. Tracked as a follow-up
-issue.
+**Status:** crypto engine + tests **done** (`resharing.rs`); the networked client ceremony
+(session type, mesh driver, CLI/UX, old-share erase) is the remaining work. Tracked in the
+resharing follow-up issue.
 
 ---
 
@@ -128,8 +143,8 @@ offer.
 
 ## 6. Investor talking points
 
-- *"Lose a laptop? Your money is fine — any two of your three devices keep signing, and you
-  re-provision the lost one without changing your address."*
+- *"Lose a laptop? Your money is fine — any two of your three devices keep signing; refresh
+  down to those two (same address), or restore the lost device from its encrypted backup."*
 - *"A stolen device is a dead end for the thief — one share can't sign, and we rotate it to
   worthless."*
 - *"We can refresh the shares on a schedule so even a patient attacker collecting fragments

--- a/packages/@mpc-wallet/frost-core/src/lib.rs
+++ b/packages/@mpc-wallet/frost-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod keystore;
 pub mod errors;
 pub mod root_secret;
 pub mod curve_registry;
+pub mod resharing;
 pub mod unified_dkg;
 pub mod hd_derivation;
 

--- a/packages/@mpc-wallet/frost-core/src/resharing.rs
+++ b/packages/@mpc-wallet/frost-core/src/resharing.rs
@@ -1,0 +1,286 @@
+//! Share refresh / resharing on top of `frost_core::keys::refresh` (#45).
+//!
+//! Refreshing re-randomises every participant's secret share **without changing
+//! the group public key** (your address is stable). It serves two ends:
+//!
+//! - **Proactive security:** rotate all shares on a schedule so shares stolen in
+//!   different epochs never combine to reach the threshold.
+//! - **Remove a device:** a quorum re-shares among a *subset*, dropping a
+//!   lost/stolen participant; that participant's old share can no longer sign.
+//!
+//! After a refresh, **old shares are useless** — an old `KeyPackage` cannot be
+//! combined with refreshed ones to produce a valid signature. That is the
+//! security property the recovery story relies on (see
+//! `docs/RECOVERY_AND_RESHARING.md`).
+//!
+//! ## What this does NOT do
+//!
+//! frost-core's refresh (both the dealerless DKG variant used here and the
+//! trusted-dealer `refresh_share`) requires **every refreshing participant to
+//! already hold a share** (`refresh_dkg_shares` takes the old `KeyPackage`). So
+//! you can rotate the existing holders or *remove* one, but you **cannot add a
+//! brand-new device that never had a share** through refresh. Bringing a fresh
+//! replacement device online is a keystore-restore (copy an existing encrypted
+//! share) or a fuller enrollment protocol — not this primitive.
+//!
+//! This module is the in-process, ciphersuite-generic engine that proves the
+//! mechanism end to end; the networked client ceremony (a `reshare` session +
+//! CLI) layers on top, exactly as the DKG client does over `keys::dkg`.
+
+use crate::errors::{FrostError, Result};
+use frost_core::keys::dkg::{part1 as dkg_part1, part2 as dkg_part2, part3 as dkg_part3};
+use frost_core::keys::refresh::{refresh_dkg_part2, refresh_dkg_part_1, refresh_dkg_shares};
+use frost_core::keys::{KeyPackage, PublicKeyPackage};
+use frost_core::{Ciphersuite, Identifier};
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+use std::collections::BTreeMap;
+
+fn ident<C: Ciphersuite>(i: u16) -> Result<Identifier<C>> {
+    Identifier::<C>::try_from(i).map_err(|e| FrostError::InvalidIdentifier(format!("{i}: {e}")))
+}
+
+fn group_key_hex<C: Ciphersuite>(p: &PublicKeyPackage<C>) -> Result<String> {
+    p.verifying_key()
+        .serialize()
+        .map(hex::encode)
+        .map_err(|e| FrostError::SerializationError(e.to_string()))
+}
+
+/// Run a fresh dealerless DKG for `total`/`threshold` (deterministic per seed).
+/// Returns each participant's key package + the shared public key package.
+/// Used as the *starting state* a refresh operates on.
+pub fn dkg_keypackages<C: Ciphersuite>(
+    total: u16,
+    threshold: u16,
+    seed_base: u8,
+) -> Result<(BTreeMap<u16, KeyPackage<C>>, PublicKeyPackage<C>)> {
+    let ids: Vec<u16> = (1..=total).collect();
+
+    // round 1
+    let mut r1_secret = BTreeMap::new();
+    let mut r1_pkgs: BTreeMap<Identifier<C>, _> = BTreeMap::new();
+    for &i in &ids {
+        let mut rng = ChaCha20Rng::from_seed([seed_base.wrapping_add(i as u8); 32]);
+        let (s, p) = dkg_part1::<C, _>(ident::<C>(i)?, total, threshold, &mut rng)
+            .map_err(|e| FrostError::DkgError(e.to_string()))?;
+        r1_secret.insert(i, s);
+        r1_pkgs.insert(ident::<C>(i)?, p);
+    }
+    // round 2
+    let mut r2_secret = BTreeMap::new();
+    let mut r2_for: BTreeMap<u16, BTreeMap<Identifier<C>, _>> = BTreeMap::new();
+    for &i in &ids {
+        let others: BTreeMap<_, _> = r1_pkgs
+            .iter()
+            .filter(|(k, _)| **k != ident::<C>(i).unwrap())
+            .map(|(k, v)| (*k, v.clone()))
+            .collect();
+        let (s, sent) = dkg_part2::<C>(r1_secret.remove(&i).unwrap(), &others)
+            .map_err(|e| FrostError::DkgError(e.to_string()))?;
+        r2_secret.insert(i, s);
+        for (rcpt, pkg) in sent {
+            r2_for.entry_by_recipient(rcpt, i, pkg, &ids);
+        }
+    }
+    // round 3
+    let mut kps = BTreeMap::new();
+    let mut pubpkg = None;
+    for &i in &ids {
+        let others_r1: BTreeMap<_, _> = r1_pkgs
+            .iter()
+            .filter(|(k, _)| **k != ident::<C>(i).unwrap())
+            .map(|(k, v)| (*k, v.clone()))
+            .collect();
+        let recv_r2 = r2_for.received_for(i)?;
+        let (kp, pp) = dkg_part3::<C>(&r2_secret[&i], &others_r1, &recv_r2)
+            .map_err(|e| FrostError::DkgError(e.to_string()))?;
+        kps.insert(i, kp);
+        pubpkg = Some(pp);
+    }
+    Ok((kps, pubpkg.unwrap()))
+}
+
+/// Refresh shares for the participant set `new_ids` (a subset of, or equal to,
+/// the current holders — every id in `new_ids` MUST already hold a share in
+/// `old_kps`). The group public key is preserved; fresh key packages are
+/// returned. Removing an id (omit it from `new_ids`) drops that participant.
+pub fn refresh<C: Ciphersuite>(
+    old_kps: &BTreeMap<u16, KeyPackage<C>>,
+    old_pub: &PublicKeyPackage<C>,
+    new_ids: &[u16],
+    threshold: u16,
+    seed_base: u8,
+) -> Result<(BTreeMap<u16, KeyPackage<C>>, PublicKeyPackage<C>)> {
+    let total = new_ids.len() as u16;
+    for id in new_ids {
+        if !old_kps.contains_key(id) {
+            return Err(FrostError::InvalidState(format!(
+                "participant {id} has no existing share to refresh"
+            )));
+        }
+    }
+
+    // refresh round 1
+    let mut r1_secret = BTreeMap::new();
+    let mut r1_pkgs: BTreeMap<Identifier<C>, _> = BTreeMap::new();
+    for &i in new_ids {
+        let mut rng = ChaCha20Rng::from_seed([seed_base.wrapping_add(i as u8); 32]);
+        let (s, p) = refresh_dkg_part_1::<C, _>(ident::<C>(i)?, total, threshold, &mut rng)
+            .map_err(|e| FrostError::DkgError(e.to_string()))?;
+        r1_secret.insert(i, s);
+        r1_pkgs.insert(ident::<C>(i)?, p);
+    }
+    // refresh round 2
+    let mut r2_secret = BTreeMap::new();
+    let mut r2_for: BTreeMap<u16, BTreeMap<Identifier<C>, _>> = BTreeMap::new();
+    for &i in new_ids {
+        let others: BTreeMap<_, _> = r1_pkgs
+            .iter()
+            .filter(|(k, _)| **k != ident::<C>(i).unwrap())
+            .map(|(k, v)| (*k, v.clone()))
+            .collect();
+        let (s, sent) = refresh_dkg_part2::<C>(r1_secret.remove(&i).unwrap(), &others)
+            .map_err(|e| FrostError::DkgError(e.to_string()))?;
+        r2_secret.insert(i, s);
+        for (rcpt, pkg) in sent {
+            r2_for.entry_by_recipient(rcpt, i, pkg, new_ids);
+        }
+    }
+    // refresh finalize — needs each participant's OLD key package + old pub key
+    let mut new_kps = BTreeMap::new();
+    let mut new_pub = None;
+    for &i in new_ids {
+        let others_r1: BTreeMap<_, _> = r1_pkgs
+            .iter()
+            .filter(|(k, _)| **k != ident::<C>(i).unwrap())
+            .map(|(k, v)| (*k, v.clone()))
+            .collect();
+        let recv_r2 = r2_for.received_for(i)?;
+        let (kp, pp) = refresh_dkg_shares::<C>(
+            &r2_secret[&i],
+            &others_r1,
+            &recv_r2,
+            old_pub.clone(),
+            old_kps[&i].clone(),
+        )
+        .map_err(|e| FrostError::DkgError(e.to_string()))?;
+        new_kps.insert(i, kp);
+        new_pub = Some(pp);
+    }
+    Ok((new_kps, new_pub.unwrap()))
+}
+
+/// Sign `msg` with the given quorum of key packages and verify against the
+/// public key package. Returns Ok(()) iff a valid threshold signature is
+/// produced — used to prove refreshed shares work and old ones don't.
+pub fn threshold_sign_verify<C: Ciphersuite>(
+    kps: &BTreeMap<u16, KeyPackage<C>>,
+    signer_ids: &[u16],
+    pubpkg: &PublicKeyPackage<C>,
+    msg: &[u8],
+) -> Result<()> {
+    use frost_core::{aggregate, round1, round2, SigningPackage};
+    let mut nonces = BTreeMap::new();
+    let mut commitments = BTreeMap::new();
+    for &i in signer_ids {
+        let kp = kps
+            .get(&i)
+            .ok_or_else(|| FrostError::InvalidState(format!("no share for signer {i}")))?;
+        let mut rng = ChaCha20Rng::from_seed([0x5a_u8.wrapping_add(i as u8); 32]);
+        let (n, c) = round1::commit(kp.signing_share(), &mut rng);
+        nonces.insert(i, n);
+        commitments.insert(ident::<C>(i)?, c);
+    }
+    let signing_package = SigningPackage::new(commitments, msg);
+    let mut shares = BTreeMap::new();
+    for &i in signer_ids {
+        let share = round2::sign(&signing_package, &nonces[&i], &kps[&i])
+            .map_err(|e| FrostError::DkgError(e.to_string()))?;
+        shares.insert(ident::<C>(i)?, share);
+    }
+    let sig = aggregate(&signing_package, &shares, pubpkg)
+        .map_err(|e| FrostError::DkgError(e.to_string()))?;
+    pubpkg
+        .verifying_key()
+        .verify(msg, &sig)
+        .map_err(|e| FrostError::DkgError(format!("verify failed: {e}")))
+}
+
+// --- small helpers to route round-2 packages by recipient ------------------
+
+trait Round2Routing<C: Ciphersuite, P> {
+    fn entry_by_recipient(&mut self, recipient: Identifier<C>, sender: u16, pkg: P, ids: &[u16]);
+    fn received_for(&self, me: u16) -> Result<BTreeMap<Identifier<C>, P>>;
+}
+
+impl<C: Ciphersuite, P: Clone> Round2Routing<C, P> for BTreeMap<u16, BTreeMap<Identifier<C>, P>> {
+    fn entry_by_recipient(&mut self, recipient: Identifier<C>, sender: u16, pkg: P, ids: &[u16]) {
+        // Map the recipient Identifier back to its u16 index.
+        for &cand in ids {
+            if let Ok(id) = ident::<C>(cand) {
+                if id == recipient {
+                    self.entry(cand).or_default().insert(ident::<C>(sender).unwrap(), pkg);
+                    return;
+                }
+            }
+        }
+    }
+    fn received_for(&self, me: u16) -> Result<BTreeMap<Identifier<C>, P>> {
+        Ok(self.get(&me).cloned().unwrap_or_default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use frost_secp256k1::Secp256K1Sha256 as Secp;
+
+    #[test]
+    fn refresh_preserves_group_key_same_set() {
+        let (kps, pp) = dkg_keypackages::<Secp>(3, 2, 10).unwrap();
+        let before = group_key_hex(&pp).unwrap();
+        let (new_kps, new_pp) = refresh::<Secp>(&kps, &pp, &[1, 2, 3], 2, 50).unwrap();
+        assert_eq!(group_key_hex(&new_pp).unwrap(), before, "group key must not change");
+        // refreshed quorum can sign
+        threshold_sign_verify::<Secp>(&new_kps, &[1, 2], &new_pp, b"after refresh").unwrap();
+    }
+
+    #[test]
+    fn old_share_cannot_mix_with_refreshed_shares() {
+        let (kps, pp) = dkg_keypackages::<Secp>(3, 2, 11).unwrap();
+        let (new_kps, new_pp) = refresh::<Secp>(&kps, &pp, &[1, 2, 3], 2, 51).unwrap();
+        // Mix an OLD share (id 1) with a NEW share (id 2) → must NOT verify.
+        let mut mixed = BTreeMap::new();
+        mixed.insert(1u16, kps[&1].clone()); // stale
+        mixed.insert(2u16, new_kps[&2].clone()); // refreshed
+        let r = threshold_sign_verify::<Secp>(&mixed, &[1, 2], &new_pp, b"mix");
+        assert!(r.is_err(), "stale + refreshed shares must not produce a valid signature");
+    }
+
+    #[test]
+    fn refresh_can_remove_a_participant() {
+        // 2-of-3 → drop participant 3, refresh among {1,2} as 2-of-2.
+        let (kps, pp) = dkg_keypackages::<Secp>(3, 2, 12).unwrap();
+        let before = group_key_hex(&pp).unwrap();
+        let (new_kps, new_pp) = refresh::<Secp>(&kps, &pp, &[1, 2], 2, 52).unwrap();
+        assert_eq!(group_key_hex(&new_pp).unwrap(), before, "address preserved after removal");
+        assert_eq!(new_kps.len(), 2, "removed participant has no new share");
+        threshold_sign_verify::<Secp>(&new_kps, &[1, 2], &new_pp, b"after removal").unwrap();
+        // The removed participant's old share is now useless against the new set.
+        let mut with_removed = new_kps.clone();
+        with_removed.insert(3u16, kps[&3].clone());
+        assert!(
+            threshold_sign_verify::<Secp>(&with_removed, &[1, 3], &new_pp, b"x").is_err(),
+            "removed participant's old share must not sign with the refreshed group"
+        );
+    }
+
+    #[test]
+    fn cannot_refresh_a_participant_without_an_existing_share() {
+        let (kps, pp) = dkg_keypackages::<Secp>(3, 2, 13).unwrap();
+        // id 9 never had a share.
+        let err = refresh::<Secp>(&kps, &pp, &[1, 2, 9], 2, 53);
+        assert!(err.is_err(), "refresh must reject a participant with no prior share");
+    }
+}


### PR DESCRIPTION
First increment of #45 (as curve_registry was for #35): a ciphersuite-generic, in-process engine over `frost_core::keys::refresh` (dealerless variant) that proves the recovery guarantees, plus a correction to the recovery doc.

`resharing.rs`: `dkg_keypackages` (starting state), `refresh(old_kps, old_pub, new_ids, threshold, …)` (rotate/remove; group key preserved), `threshold_sign_verify`.

Tests (secp256k1): refresh preserves the group key + refreshed quorum signs; an **old share can't mix with refreshed shares** (rotation); a device can be **removed** (3→2, address preserved, removed share useless); refresh **rejects** a participant with no prior share.

Honest scope: frost-core refresh can rotate/remove but **cannot add a brand-new device** (it needs each participant's old KeyPackage) — the doc is corrected to point a fresh replacement device at keystore-restore. The networked client ceremony (reshare session + CLI) is the remaining work on #45.

Refs #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)