### PR TITLE
feat(reshare): SessionType::Reshare + discovery plumbing — phase 2 (#45)

### DIFF
--- a/apps/cli-node/src/bridge.rs
+++ b/apps/cli-node/src/bridge.rs
@@ -112,6 +112,7 @@ impl Bridge {
                     // dkg→signing transition on the same id surface once each.
                     let dedup_key = match &session.session_type {
                         SessionType::Signing { .. } => format!("sign:{}", session.session_id),
+                        SessionType::Reshare { .. } => format!("reshare:{}", session.session_id),
                         SessionType::DKG => format!("dkg:{}", session.session_id),
                     };
                     if self.announced_sessions.insert(dedup_key) {
@@ -121,6 +122,18 @@ impl Bridge {
                         match &session.session_type {
                             SessionType::Signing { wallet_name, .. } => {
                                 events.push(CliEvent::SigningRequest {
+                                    session_id: session.session_id.clone(),
+                                    wallet: wallet_name.clone(),
+                                    threshold: session.threshold,
+                                    total: session.total,
+                                    proposer: session.proposer_id.clone(),
+                                });
+                            }
+                            SessionType::Reshare { wallet_name, .. } => {
+                                // A co-signer approves a reshare by joining its
+                                // session (contributing a refreshed share), same
+                                // as signing. Surface it as a reshare_request.
+                                events.push(CliEvent::ReshareRequest {
                                     session_id: session.session_id.clone(),
                                     wallet: wallet_name.clone(),
                                     threshold: session.threshold,
@@ -235,6 +248,7 @@ fn session_entry(s: &SessionInfo) -> SessionEntry {
     let session_type = match &s.session_type {
         SessionType::DKG => "dkg".to_string(),
         SessionType::Signing { .. } => "signing".to_string(),
+        SessionType::Reshare { .. } => "reshare".to_string(),
     };
     SessionEntry {
         session_id: s.session_id.clone(),

--- a/apps/cli-node/src/protocol.rs
+++ b/apps/cli-node/src/protocol.rs
@@ -140,6 +140,15 @@ pub enum CliEvent {
         total: u16,
         proposer: String,
     },
+    /// An incoming share-refresh/resharing request we're a participant for
+    /// (discovered). A co-signer approves by joining the session (#45).
+    ReshareRequest {
+        session_id: String,
+        wallet: String,
+        threshold: u16,
+        total: u16,
+        proposer: String,
+    },
     /// A threshold signing ceremony finished.
     SignatureComplete {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -221,6 +230,7 @@ pub fn schema_json() -> String {
             {"event": "dkg_progress", "fields": {"session_id": "string", "round": "u8", "received": "usize", "need": "usize"}},
             {"event": "dkg_complete", "fields": {"correlates?": "u64", "wallet_id": "string", "address": "string", "group_public_key": "string"}},
             {"event": "signing_request", "fields": {"session_id": "string", "wallet": "string", "threshold": "u16", "total": "u16", "proposer": "string"}},
+            {"event": "reshare_request", "fields": {"session_id": "string", "wallet": "string", "threshold": "u16", "total": "u16", "proposer": "string"}},
             {"event": "signature_complete", "fields": {"correlates?": "u64", "signature": "string", "message_hash": "string"}},
             {"event": "error", "fields": {"correlates?": "u64", "code": "string", "message": "string"}}
         ]

--- a/apps/tui-node/src/elm/app.rs
+++ b/apps/tui-node/src/elm/app.rs
@@ -280,6 +280,7 @@ where
                             session_type: match s.session_type {
                                 crate::protocal::signal::SessionType::DKG => SessionType::DKG,
                                 crate::protocal::signal::SessionType::Signing { .. } => SessionType::Signing,
+                                crate::protocal::signal::SessionType::Reshare { .. } => SessionType::Reshare,
                             },
                             creator: s.proposer_id.clone(),
                             status: SessionStatus::Waiting,

--- a/apps/tui-node/src/elm/components/join_session.rs
+++ b/apps/tui-node/src/elm/components/join_session.rs
@@ -44,6 +44,7 @@ pub struct SessionInfo {
 pub enum SessionType {
     DKG,
     Signing,
+    Reshare,
 }
 
 #[derive(Debug, Clone)]
@@ -356,8 +357,12 @@ impl JoinSessionComponent {
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded)
                     .border_style(Style::default().fg(status_color))
-                    .title(format!(" {} Details ", 
-                        if session.session_type == SessionType::DKG { "DKG" } else { "Signing" }
+                    .title(format!(" {} Details ",
+                        match session.session_type {
+                            SessionType::DKG => "DKG",
+                            SessionType::Signing => "Signing",
+                            SessionType::Reshare => "Reshare",
+                        }
                     ))
                     .title_style(Style::default().fg(status_color).add_modifier(Modifier::BOLD))
             );

--- a/apps/tui-node/src/elm/update.rs
+++ b/apps/tui-node/src/elm/update.rs
@@ -580,6 +580,19 @@ pub fn update(model: &mut Model, msg: Message) -> Option<Command> {
                                 .clone(),
                         })
                     }
+                    crate::protocal::signal::SessionType::Reshare { wallet_name, .. } => {
+                        // Phase 2 (#45): the Reshare session type exists, but the
+                        // joiner ceremony (unlock → JoinReshare over the mesh) is
+                        // wired in a later phase. Don't silently no-op into a
+                        // confusing state — clear the pending password and warn.
+                        warn!(
+                            "SubmitPassword on reshare session {} (wallet '{}') — \
+                             reshare ceremony not yet wired; ignoring",
+                            session_id, wallet_name
+                        );
+                        model.wallet_state.pending_password = None;
+                        None
+                    }
                 }
             } else if let Some(cw) = model.wallet_state.creating_wallet.clone() {
                 // Creator path — build the `WalletConfig` out of whatever

--- a/apps/tui-node/src/protocal/signal.rs
+++ b/apps/tui-node/src/protocal/signal.rs
@@ -35,6 +35,15 @@ pub enum SessionType {
         blockchain: String,
         group_public_key: String,
     },
+    /// Share refresh / resharing of an existing wallet (#45). Carries the OLD
+    /// group public key so a joiner only participates if it owns that wallet;
+    /// `participants` (on the enclosing `SessionInfo`) is the RETAINED signer
+    /// set after the refresh (a removed device simply isn't listed).
+    Reshare {
+        wallet_name: String,
+        curve_type: String,
+        group_public_key: String,
+    },
 }
 // Import the DKG Package type
 // Import round1 and round2 packages
@@ -281,5 +290,46 @@ impl From<RTCIceCandidateInit> for CandidateInfo {
 impl From<RTCSessionDescription> for SDPInfo {
     fn from(desc: RTCSessionDescription) -> Self {
         SDPInfo { sdp: desc.sdp }
+    }
+}
+
+#[cfg(test)]
+mod reshare_type_tests {
+    use super::*;
+
+    #[test]
+    fn reshare_session_type_serde_roundtrips() {
+        let st = SessionType::Reshare {
+            wallet_name: "wallet-ab12".into(),
+            curve_type: "secp256k1".into(),
+            group_public_key: "02deadbeef".into(),
+        };
+        let json = serde_json::to_string(&st).unwrap();
+        // Tagged shape: {"type":"Reshare","data":{...}} — co-existing with DKG/Signing.
+        assert!(json.contains("\"type\":\"Reshare\""), "got {json}");
+        let back: SessionType = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, st);
+    }
+
+    #[test]
+    fn reshare_session_info_roundtrips_with_retained_participants() {
+        let info = SessionInfo {
+            session_id: "reshare_x".into(),
+            proposer_id: "alice".into(),
+            total: 2,
+            threshold: 2,
+            participants: vec!["alice".into(), "carol".into()], // retained set (bob removed)
+            session_type: SessionType::Reshare {
+                wallet_name: "W".into(),
+                curve_type: "ed25519".into(),
+                group_public_key: "abcd".into(),
+            },
+            curve_type: "ed25519".into(),
+            coordination_type: "online".into(),
+            signing_message_hex: None,
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        let back: SessionInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, info);
     }
 }


### PR DESCRIPTION
Phase 2 of the networked reshare ceremony (per `docs/RESHARE_CEREMONY_DESIGN.md`): the wire/session type + discovery wiring, **no driver yet**. Compiles; all tests green; zero behavior change to existing flows.

- `SessionType::Reshare { wallet_name, curve_type, group_public_key }` (+ serde round-trip tests)
- `CliEvent::ReshareRequest` + schema entry; bridge surfaces discovered reshare sessions as `reshare_request`, dedup `reshare:<id>`, session_entry "reshare"
- TUI join_session UI gains a Reshare label
- exhaustive-match arms added (joiner fork is an honest "not yet wired" stub; driver lands phase 3)

31 cli tests + event_contract golden + tui serde tests green; tui-node/cli/native compile.

Refs #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)