### PR TITLE
feat(reshare): mesh transport for reshare rounds — phase 4b-1 (#45)

### DIFF
--- a/apps/tui-node/src/elm/message.rs
+++ b/apps/tui-node/src/elm/message.rs
@@ -133,6 +133,8 @@ pub enum Message {
     StartDKGProtocol,  // Trigger the actual DKG protocol when mesh is ready
     ProcessDKGRound1 { from_device: String, package_bytes: Vec<u8> },  // Process received DKG Round 1 package
     ProcessDKGRound2 { from_device: String, package_bytes: Vec<u8> },  // Process received DKG Round 2 package
+    ProcessReshareRound1 { from_device: String, package_bytes: Vec<u8> }, // Reshare round 1 from a peer (#45)
+    ProcessReshareRound2 { from_device: String, package_bytes: Vec<u8> }, // Reshare round 2 from a peer (#45)
     DKGKeyGenerated { group_pubkey_hex: String },                      // Final FROST key ready
     /// Fires after `Command::UnlockWallet` successfully decrypted the
     /// wallet file and stashed `KeyPackage` + `PublicKeyPackage` on

--- a/apps/tui-node/src/elm/update.rs
+++ b/apps/tui-node/src/elm/update.rs
@@ -1478,6 +1478,27 @@ pub fn update(model: &mut Model, msg: Message) -> Option<Command> {
             })
         }
 
+        Message::ProcessReshareRound1 { from_device, package_bytes } => {
+            // Transport wired (#45 phase 4b-1). The command handlers that drive
+            // `protocal::reshare` over the mesh land in 4b-2 (#56); until then a
+            // received reshare round-1 package is logged and dropped. Nothing
+            // initiates a reshare yet (StartReshare is 4b-2), so none arrive.
+            info!(
+                "reshare round-1 from {} ({} bytes) — driver not yet wired (#56)",
+                from_device,
+                package_bytes.len()
+            );
+            None
+        }
+        Message::ProcessReshareRound2 { from_device, package_bytes } => {
+            info!(
+                "reshare round-2 from {} ({} bytes) — driver not yet wired (#56)",
+                from_device,
+                package_bytes.len()
+            );
+            None
+        }
+
         Message::ProcessDKGRound2 { from_device, package_bytes } => {
             // First peer Round 2 package → we've clearly advanced past Round 1.
             // Update the UI label. Idempotent: we only transition on the first

--- a/apps/tui-node/src/network/webrtc.rs
+++ b/apps/tui-node/src/network/webrtc.rs
@@ -129,6 +129,44 @@ pub async fn dispatch_data_channel_msg<C>(
                 }
                 return;
             }
+            // Reshare-round frames (#45): same shape as DKG rounds, different
+            // prefix. Routed to the reshare driver via Message::ProcessReshareRound*.
+            if let Some(package_data) = msg_text.strip_prefix("RESHARE_ROUND1:") {
+                info!("🔄 Received RESHARE Round 1 package from {}", device_id_recv);
+                match BASE64.decode(package_data) {
+                    Ok(package_bytes) => {
+                        if let Some(tx) = &ui_msg_tx {
+                            let _ = tx.send(crate::elm::message::Message::ProcessReshareRound1 {
+                                from_device: device_id_recv.clone(),
+                                package_bytes,
+                            });
+                        }
+                    }
+                    Err(e) => error!(
+                        "Failed to base64-decode RESHARE Round 1 package from {}: {}",
+                        device_id_recv, e
+                    ),
+                }
+                return;
+            }
+            if let Some(package_data) = msg_text.strip_prefix("RESHARE_ROUND2:") {
+                info!("🔄 Received RESHARE Round 2 package from {}", device_id_recv);
+                match BASE64.decode(package_data) {
+                    Ok(package_bytes) => {
+                        if let Some(tx) = &ui_msg_tx {
+                            let _ = tx.send(crate::elm::message::Message::ProcessReshareRound2 {
+                                from_device: device_id_recv.clone(),
+                                package_bytes,
+                            });
+                        }
+                    }
+                    Err(e) => error!(
+                        "Failed to base64-decode RESHARE Round 2 package from {}: {}",
+                        device_id_recv, e
+                    ),
+                }
+                return;
+            }
             // Phase C: signing-round frames. Same shape as DKG rounds,
             // different prefix. Constants in `protocal::signing` keep the
             // string literals single-sourced.

--- a/apps/tui-node/src/protocal/signal.rs
+++ b/apps/tui-node/src/protocal/signal.rs
@@ -222,6 +222,17 @@ pub enum WebRTCMessage<C: Ciphersuite> {
     DkgRound2Package {
         package: frost_core::keys::dkg::round2::Package<C>,
     },
+    /// Reshare (share refresh) round-1 package — broadcast to all retained
+    /// peers, exactly like `DkgRound1Package`. Refresh reuses frost's dkg
+    /// round-1 Package type (#45).
+    ReshareRound1Package {
+        package: frost_core::keys::dkg::round1::Package<C>,
+    },
+    /// Reshare round-2 package — sent point-to-point to one recipient (the
+    /// sender is the data-channel peer), mirroring `DkgRound2Package`.
+    ReshareRound2Package {
+        package: frost_core::keys::dkg::round2::Package<C>,
+    },
     /// Data channel opened notification
     ChannelOpen {
         device_id: String,

--- a/apps/tui-node/src/utils/device.rs
+++ b/apps/tui-node/src/utils/device.rs
@@ -451,6 +451,18 @@ pub async fn setup_data_channel_callbacks<C>(
                                         package,
                                     });
                             }
+                            WebRTCMessage::ReshareRound1Package { .. }
+                            | WebRTCMessage::ReshareRound2Package { .. } => {
+                                // The reshare ceremony (#45) runs on the elm headless
+                                // path (network/webrtc.rs → Message::ProcessReshareRound*).
+                                // This legacy ratatui InternalCommand path doesn't drive
+                                // reshare yet (phase 5), so ignore here.
+                                tracing::debug!(
+                                    "reshare round package from {} on legacy device.rs path — ignored \
+                                     (reshare runs via the elm path)",
+                                    device_id
+                                );
+                            }
                             WebRTCMessage::SimpleMessage { text } => {
                                 // Parse DKG messages from SimpleMessage format
                                 if text.starts_with("DKG_ROUND1:") {


### PR DESCRIPTION
Transport plumbing for the reshare ceremony, sliced to land compilable on its own:
- `WebRTCMessage::ReshareRound1/2Package` (reuse frost dkg round Package types) + `Message::ProcessReshareRound1/2`
- webrtc.rs (elm/headless path): route `RESHARE_ROUND1/2:` frames → Message
- device.rs (legacy path): log-and-ignore; update.rs: log no-op for now

The command handlers that drive `protocal::reshare` + broadcast + StartReshare initiation land in 4b-2 (#56); nothing initiates a reshare yet so no packets flow. Compiles tui-node/cli/native; reshare tests green.

Refs #45 #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)