### PR TITLE
feat(reshare): §3 identifier rule + AppState plumbing — phase 4b-2 (part) (#45)

### DIFF
--- a/apps/tui-node/src/protocal/reshare.rs
+++ b/apps/tui-node/src/protocal/reshare.rs
@@ -30,6 +30,19 @@ use frost_core::{Ciphersuite, Identifier};
 
 use crate::utils::appstate_compat::AppState;
 
+/// FROST identifier for `device_id` in a reshare — derived from the wallet's
+/// **ORIGINAL** participant set (design §3), NOT the retained set. Removing a
+/// device must not renumber the survivors (their old key packages carry their
+/// original ids), so we always canonicalise over the full original list
+/// (persisted in `WalletMetadata.participants`). Using the reduced set here
+/// would silently mis-key the refresh and corrupt the result.
+pub fn reshare_identifier<C: Ciphersuite>(
+    original_participants: &[String],
+    device_id: &str,
+) -> Option<Identifier<C>> {
+    crate::protocal::dkg::canonical_identifier::<C>(original_participants, device_id)
+}
+
 /// Round 1: produce this node's refresh round-1 package and stash the secret.
 /// `max_signers` = number of RETAINED participants; `min_signers` = the
 /// (unchanged) threshold; `identifier` = this node's ORIGINAL id.
@@ -216,6 +229,25 @@ mod tests {
             assert!(states[&k].reshare_round1_packages.is_empty());
         }
         keys
+    }
+
+    #[test]
+    fn reshare_identifier_uses_original_set_not_reduced() {
+        // Original sorted: alice=1, bob=2, carol=3.
+        let original = vec!["alice".to_string(), "bob".to_string(), "carol".to_string()];
+        assert_eq!(reshare_identifier::<Secp>(&original, "alice"), Identifier::<Secp>::try_from(1).ok());
+        assert_eq!(reshare_identifier::<Secp>(&original, "carol"), Identifier::<Secp>::try_from(3).ok());
+        // Removing the MIDDLE device (bob): survivors must KEEP their original ids.
+        // The wrong approach (canonicalise over the reduced {alice,carol}) would
+        // make carol=2 — proving why we must use the original set.
+        let reduced = vec!["alice".to_string(), "carol".to_string()];
+        let wrong = crate::protocal::dkg::canonical_identifier::<Secp>(&reduced, "carol");
+        assert_eq!(wrong, Identifier::<Secp>::try_from(2).ok(), "reduced-set id is 2 (wrong)");
+        assert_ne!(
+            reshare_identifier::<Secp>(&original, "carol"),
+            wrong,
+            "reshare must NOT renumber carol — keep original id 3"
+        );
     }
 
     #[test]

--- a/apps/tui-node/src/utils/appstate_compat.rs
+++ b/apps/tui-node/src/utils/appstate_compat.rs
@@ -84,6 +84,12 @@ pub struct AppState<C: Ciphersuite> {
         std::collections::BTreeMap<frost_core::Identifier<C>, frost_core::keys::dkg::round1::Package<C>>,
     pub reshare_round2_packages:
         std::collections::BTreeMap<frost_core::Identifier<C>, frost_core::keys::dkg::round2::Package<C>>,
+    /// The wallet's ORIGINAL participant list (from keystore metadata), used to
+    /// map device_id → original FROST id during a reshare (design §3 — must NOT
+    /// recompute over the retained set). Set when the reshare loads the wallet.
+    pub reshare_original_participants: Vec<String>,
+    /// Wallet id being reshared (so finalize knows which keystore to overwrite).
+    pub reshare_wallet_id: Option<String>,
     pub pending_mesh_ready_signals: std::collections::HashSet<String>,
     // Additional fields for UI compatibility
     pub websocket_connected: bool,
@@ -184,6 +190,8 @@ where
             reshare_round2_secret: None,
             reshare_round1_packages: std::collections::BTreeMap::new(),
             reshare_round2_packages: std::collections::BTreeMap::new(),
+            reshare_original_participants: Vec::new(),
+            reshare_wallet_id: None,
             pending_mesh_ready_signals: std::collections::HashSet::new(),
             websocket_connected: false,
             websocket_connecting: false,
@@ -261,6 +269,8 @@ where
             reshare_round2_secret: None,
             reshare_round1_packages: std::collections::BTreeMap::new(),
             reshare_round2_packages: std::collections::BTreeMap::new(),
+            reshare_original_participants: Vec::new(),
+            reshare_wallet_id: None,
             pending_mesh_ready_signals: std::collections::HashSet::new(),
             websocket_connected: false,
             websocket_connecting: false,


### PR DESCRIPTION
Delivers 4b-2's **correctness linchpin** tested, rather than unexercised glue:
- `reshare_identifier(original_participants, device_id)` — ids over the ORIGINAL set so removing a middle device doesn't renumber survivors (their old key packages carry the original ids). Unit-tested (proves reduced-set id 3→2 would be wrong).
- AppState: `reshare_original_participants` + `reshare_wallet_id`.

The remaining async command handlers (Start/JoinReshare announce, broadcast, mesh-ready trigger, password-stash, finalize emit) are mesh orchestration only the **4c L3 multi-process test** exercises — tracked in #56 to be written with that harness, not landed unexercised. Driver core (phase 3) + this id rule are the validated foundation. tui-node compiles; reshare tests green.

Refs #45 #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)