### PR TITLE
feat(reshare): networked same-set reshare ceremony over the live mesh — phase 4b (#45)

### DIFF
--- a/apps/cli-node/src/simulate.rs
+++ b/apps/cli-node/src/simulate.rs
@@ -81,6 +81,7 @@ enum Evt {
     SessionDiscovered { id: String, signing: bool },
     DkgDone { wallet_id: String, group_key: String },
     SignDone { signature: String, message: String },
+    ReshareDone { group_key: String },
 }
 
 fn watcher() -> (
@@ -109,6 +110,11 @@ fn watcher() -> (
                     let _ = tx.send(Evt::DkgDone {
                         wallet_id: wallet_id.clone(),
                         group_key: group_pubkey_hex.clone(),
+                    });
+                }
+                Message::ReshareComplete { group_public_key, .. } => {
+                    let _ = tx.send(Evt::ReshareDone {
+                        group_key: group_public_key.clone(),
                     });
                 }
                 Message::SigningComplete {
@@ -372,6 +378,87 @@ pub async fn run_signing_simulation_enc(
         signature,
         signed_message,
         verified,
+        elapsed_ms: started.elapsed().as_millis(),
+    })
+}
+
+/// Outcome of a networked reshare end-to-end run (#45 4b).
+#[derive(Debug, Serialize)]
+pub struct ReshareE2eResult {
+    pub nodes: usize,
+    pub threshold: u16,
+    pub curve: String,
+    pub dkg_group_public_key: String,
+    /// Group key reported by every node after the reshare.
+    pub reshare_group_public_key: String,
+    /// True iff every node's post-reshare group key == the DKG group key.
+    pub key_preserved: bool,
+    /// True iff a threshold signature with the REFRESHED shares verifies.
+    pub signed_after_reshare: bool,
+    pub elapsed_ms: u128,
+}
+
+impl ReshareE2eResult {
+    pub fn to_json(&self) -> String {
+        serde_json::to_string_pretty(self).unwrap_or_default()
+    }
+    pub fn ok(&self) -> bool {
+        self.key_preserved && self.signed_after_reshare
+    }
+}
+
+/// Networked reshare end to end over the real WebRTC mesh: run DKG, then trigger
+/// a same-set reshare on every node (reusing the live mesh), confirm all nodes
+/// preserve the group key, and finally sign with the REFRESHED shares + verify.
+pub async fn run_reshare_e2e(opts: SimulateOpts, message: &str) -> anyhow::Result<ReshareE2eResult> {
+    let nodes = opts.nodes;
+    let threshold = opts.threshold;
+    let started = Instant::now();
+    let mut c = dkg_cluster(&opts).await?;
+    if !c.agreed {
+        anyhow::bail!("DKG did not agree; aborting reshare");
+    }
+    let dkg_group_key = c.group_key.clone();
+    let wallet_id = c.outcomes[0].wallet_id.clone();
+
+    // Trigger a reshare on every node — each refreshes its share over the mesh.
+    for s in c.senders.iter() {
+        s.send(Message::HeadlessReshare { password: "sim-password-0".into() })?;
+    }
+    // Every node must report reshare completion with the unchanged group key.
+    let mut reshare_keys = Vec::new();
+    for rx in c.receivers.iter_mut() {
+        let done = wait_for(rx, opts.timeout_secs, |e| matches!(e, Evt::ReshareDone { .. })).await?;
+        if let Evt::ReshareDone { group_key } = done {
+            reshare_keys.push(group_key);
+        }
+    }
+    let key_preserved = reshare_keys.len() == nodes
+        && reshare_keys.iter().all(|k| *k == dkg_group_key);
+    let reshare_group_key = reshare_keys.first().cloned().unwrap_or_default();
+
+    // Sign with the REFRESHED shares and verify against the (unchanged) group key.
+    let (signature, signed_message) = drive_signing(
+        &c.senders,
+        &mut c.receivers,
+        wallet_id,
+        message,
+        "utf8",
+        threshold,
+        opts.timeout_secs,
+    )
+    .await?;
+    let signed_after_reshare =
+        verify_signature(&opts.curve, &dkg_group_key, &signed_message, &signature).unwrap_or(false);
+
+    Ok(ReshareE2eResult {
+        nodes,
+        threshold,
+        curve: opts.curve.clone(),
+        dkg_group_public_key: dkg_group_key,
+        reshare_group_public_key: reshare_group_key,
+        key_preserved,
+        signed_after_reshare,
         elapsed_ms: started.elapsed().as_millis(),
     })
 }

--- a/apps/cli-node/tests/e2e_dkg.rs
+++ b/apps/cli-node/tests/e2e_dkg.rs
@@ -87,3 +87,32 @@ async fn dkg_then_sign_2_of_2_verifies() {
         &result.signature[..16.min(result.signature.len())]
     );
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+#[ignore = "real WebRTC reshare over loopback; run with --ignored"]
+async fn reshare_then_sign_2_of_3_preserves_group_key() {
+    // #45 4b: networked same-set reshare over the live mesh. After DKG, every
+    // node refreshes its share; the group key (address) must be unchanged and a
+    // threshold signature with the REFRESHED shares must verify.
+    init_logs();
+    let r = mpc_wallet_cli::simulate::run_reshare_e2e(
+        mpc_wallet_cli::simulate::SimulateOpts {
+            nodes: 3,
+            threshold: 2,
+            curve: "secp256k1".into(),
+            signal_url: None,
+            timeout_secs: 120,
+        },
+        "reshared then signed",
+    )
+    .await
+    .expect("reshare e2e ran");
+
+    assert!(r.key_preserved, "group key changed across reshare: {r:?}");
+    assert_eq!(r.dkg_group_public_key, r.reshare_group_public_key);
+    assert!(r.signed_after_reshare, "refreshed shares failed to sign: {r:?}");
+    eprintln!(
+        "✅ reshare e2e ok in {}ms, group preserved = {}",
+        r.elapsed_ms, r.dkg_group_public_key
+    );
+}

--- a/apps/tui-node/src/elm/command.rs
+++ b/apps/tui-node/src/elm/command.rs
@@ -59,6 +59,13 @@ pub enum Command {
     /// Calls `protocal::dkg::process_dkg_round2` which finalises the key with
     /// `part3` once all Round 2 packages for us have arrived.
     ProcessDKGRound2 { from_device: String, package_bytes: Vec<u8> },
+    /// Begin a same-set reshare on this node (#45): refresh part 1 over the
+    /// current session's live mesh, then broadcast. Triggered by HeadlessReshare.
+    StartReshare { password: String },
+    /// Process a peer's reshare round-1 / round-2 package received over a data
+    /// channel — drives `protocal::reshare`.
+    ProcessReshareRound1 { from_device: String, package_bytes: Vec<u8> },
+    ProcessReshareRound2 { from_device: String, package_bytes: Vec<u8> },
     JoinDKG {
         session_id: String,
         /// Session shape known to the joiner from the discovered announcement.
@@ -852,6 +859,55 @@ impl Command {
                         group_pubkey_hex: hex,
                     });
                 }
+            }
+
+            Command::StartReshare { password } => {
+                // Same-set reshare reusing the current session's live mesh (#45).
+                // Seed the reshare context from the active session + loaded
+                // wallet, then trigger round 1 on this node.
+                let self_id = {
+                    let mut state = app_state.lock().await;
+                    if let Some(session) = state.session.clone() {
+                        if state.reshare_original_participants.is_empty() {
+                            state.reshare_original_participants = session.participants.clone();
+                        }
+                        if state.reshare_wallet_id.is_none() {
+                            state.reshare_wallet_id = state
+                                .current_wallet_id
+                                .clone()
+                                .or(Some(session.session_id.clone()));
+                        }
+                    }
+                    let _ = password; // share re-encryption on persist — #56
+                    state.device_id.clone()
+                };
+                crate::protocal::reshare::handle_trigger_reshare_round1(app_state.clone(), self_id)
+                    .await;
+            }
+
+            Command::ProcessReshareRound1 {
+                from_device,
+                package_bytes,
+            } => {
+                crate::protocal::reshare::process_reshare_round1(
+                    app_state.clone(),
+                    from_device,
+                    package_bytes,
+                )
+                .await;
+            }
+
+            Command::ProcessReshareRound2 {
+                from_device,
+                package_bytes,
+            } => {
+                crate::protocal::reshare::process_reshare_round2(
+                    app_state.clone(),
+                    from_device,
+                    package_bytes,
+                    tx.clone(),
+                )
+                .await;
             }
 
             Command::ProcessDKGRound2 {

--- a/apps/tui-node/src/elm/message.rs
+++ b/apps/tui-node/src/elm/message.rs
@@ -45,6 +45,18 @@ pub enum Message {
         encoding: String,
         password: String,
     },
+    /// Headless trigger: begin a same-set reshare on this node, reusing the
+    /// current session's live mesh (#45). Every retained node receives this to
+    /// start its round 1.
+    HeadlessReshare {
+        password: String,
+    },
+    /// A reshare ceremony finished on this node (group key preserved). Tapped by
+    /// the CLI bridge / simulate harness.
+    ReshareComplete {
+        wallet_id: String,
+        group_public_key: String,
+    },
     /// Request the active-session replay (`RequestActiveSessions`) over the
     /// primary WebSocket. The interactive TUI fires this implicitly on
     /// entering the Join-Session screen; headless front-ends (native, CLI)

--- a/apps/tui-node/src/elm/update.rs
+++ b/apps/tui-node/src/elm/update.rs
@@ -1479,23 +1479,17 @@ pub fn update(model: &mut Model, msg: Message) -> Option<Command> {
         }
 
         Message::ProcessReshareRound1 { from_device, package_bytes } => {
-            // Transport wired (#45 phase 4b-1). The command handlers that drive
-            // `protocal::reshare` over the mesh land in 4b-2 (#56); until then a
-            // received reshare round-1 package is logged and dropped. Nothing
-            // initiates a reshare yet (StartReshare is 4b-2), so none arrive.
-            info!(
-                "reshare round-1 from {} ({} bytes) — driver not yet wired (#56)",
-                from_device,
-                package_bytes.len()
-            );
-            None
+            Some(Command::ProcessReshareRound1 { from_device, package_bytes })
         }
         Message::ProcessReshareRound2 { from_device, package_bytes } => {
-            info!(
-                "reshare round-2 from {} ({} bytes) — driver not yet wired (#56)",
-                from_device,
-                package_bytes.len()
-            );
+            Some(Command::ProcessReshareRound2 { from_device, package_bytes })
+        }
+        Message::HeadlessReshare { password } => {
+            Some(Command::StartReshare { password })
+        }
+        Message::ReshareComplete { .. } => {
+            // Terminal event; tapped by the CLI bridge / simulate harness. No
+            // model transition needed.
             None
         }
 

--- a/apps/tui-node/src/protocal/reshare.rs
+++ b/apps/tui-node/src/protocal/reshare.rs
@@ -161,6 +161,219 @@ pub fn clear_reshare_state<C: Ciphersuite>(state: &mut AppState<C>) {
     state.reshare_in_progress = false;
 }
 
+// =====================================================================
+// Async mesh orchestration (#45 4b). Same-set reshare reusing the live
+// post-DKG WebRTC mesh: each node triggers round 1, the round packages flow
+// over the existing data channels (RESHARE_ROUND1/2: frames, routed in
+// network/webrtc.rs), and each node finalizes to the unchanged group key.
+//
+// Scope: same participant set (every original participant stays). Reshare with
+// a *reduced* set (device removal) needs a fresh announce/join to form a new
+// mesh — tracked in #56. Keystore persistence of the refreshed share also needs
+// password-stash plumbing (#56); finalize here swaps the in-memory share and
+// emits ReshareComplete (enough to keep signing with the new shares).
+// =====================================================================
+
+use crate::elm::message::Message;
+use crate::protocal::signal::WebRTCMessage;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tokio::sync::mpsc::UnboundedSender;
+use tracing::{error, info};
+
+fn b64(bytes: &[u8]) -> String {
+    use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+    BASE64.encode(bytes)
+}
+
+/// Begin a reshare on this node: refresh part 1 over the current session/mesh,
+/// then broadcast our round-1 package to the retained peers.
+pub async fn handle_trigger_reshare_round1<C>(state: Arc<Mutex<AppState<C>>>, self_device_id: String)
+where
+    C: Ciphersuite + Send + Sync + 'static,
+{
+    let (participants, pkg_bytes) = {
+        let mut guard = state.lock().await;
+        let session = match &guard.session {
+            Some(s) => s.clone(),
+            None => {
+                error!("reshare round1: no active session");
+                return;
+            }
+        };
+        if guard.reshare_original_participants.is_empty() {
+            guard.reshare_original_participants = session.participants.clone();
+        }
+        let original = guard.reshare_original_participants.clone();
+        let my_id = match reshare_identifier::<C>(&original, &self_device_id) {
+            Some(id) => id,
+            None => {
+                error!("reshare round1: {} not in original participants", self_device_id);
+                return;
+            }
+        };
+        let pkg = match reshare_part1(&mut guard, my_id, session.total, session.threshold) {
+            Ok(p) => p,
+            Err(e) => {
+                error!("reshare round1: {e}");
+                return;
+            }
+        };
+        let bytes = match pkg.serialize() {
+            Ok(b) => b,
+            Err(e) => {
+                error!("reshare round1 serialize: {e}");
+                return;
+            }
+        };
+        (session.participants.clone(), bytes)
+    };
+
+    let msg = WebRTCMessage::<C>::SimpleMessage { text: format!("RESHARE_ROUND1:{}", b64(&pkg_bytes)) };
+    for peer in participants.iter().filter(|p| **p != self_device_id) {
+        let _ = crate::utils::device::send_webrtc_message(peer, &msg, state.clone()).await;
+    }
+    info!("📡 reshare round-1 broadcast to {} peers", participants.len().saturating_sub(1));
+}
+
+/// Ingest a peer's round-1 package; when all peers' are in, advance to round 2.
+pub async fn process_reshare_round1<C>(
+    state: Arc<Mutex<AppState<C>>>,
+    from_device_id: String,
+    package_bytes: Vec<u8>,
+) where
+    C: Ciphersuite + Send + Sync + 'static,
+{
+    let advance = {
+        let mut guard = state.lock().await;
+        let session = match &guard.session {
+            Some(s) => s.clone(),
+            None => return,
+        };
+        // A peer's round-1 may arrive before our own trigger ran; seed the
+        // original participant set from the session so the id map works either way.
+        if guard.reshare_original_participants.is_empty() {
+            guard.reshare_original_participants = session.participants.clone();
+        }
+        let original = guard.reshare_original_participants.clone();
+        let sender = match reshare_identifier::<C>(&original, &from_device_id) {
+            Some(id) => id,
+            None => {
+                error!("reshare round1 from unknown device {from_device_id}");
+                return;
+            }
+        };
+        let pkg = match frost_core::keys::dkg::round1::Package::<C>::deserialize(&package_bytes) {
+            Ok(p) => p,
+            Err(e) => {
+                error!("reshare round1 deserialize: {e}");
+                return;
+            }
+        };
+        add_reshare_round1(&mut guard, sender, pkg);
+        let need = (session.total as usize).saturating_sub(1);
+        guard.reshare_round1_packages.len() >= need && need > 0
+    };
+    if advance {
+        let self_id = state.lock().await.device_id.clone();
+        handle_trigger_reshare_round2(state, self_id).await;
+    }
+}
+
+/// Produce round-2 packages and send each retained peer its own.
+pub async fn handle_trigger_reshare_round2<C>(state: Arc<Mutex<AppState<C>>>, self_device_id: String)
+where
+    C: Ciphersuite + Send + Sync + 'static,
+{
+    let (participants, original, per_recipient) = {
+        let mut guard = state.lock().await;
+        let session = match &guard.session {
+            Some(s) => s.clone(),
+            None => return,
+        };
+        let original = guard.reshare_original_participants.clone();
+        let out = match reshare_part2(&mut guard) {
+            Ok(o) => o,
+            Err(e) => {
+                error!("reshare round2: {e}");
+                return;
+            }
+        };
+        (session.participants.clone(), original, out)
+    };
+
+    for peer in participants.iter().filter(|p| **p != self_device_id) {
+        let pid = match reshare_identifier::<C>(&original, peer) {
+            Some(id) => id,
+            None => continue,
+        };
+        if let Some(pkg) = per_recipient.get(&pid) {
+            if let Ok(bytes) = pkg.serialize() {
+                let msg = WebRTCMessage::<C>::SimpleMessage {
+                    text: format!("RESHARE_ROUND2:{}", b64(&bytes)),
+                };
+                let _ = crate::utils::device::send_webrtc_message(peer, &msg, state.clone()).await;
+            }
+        }
+    }
+}
+
+/// Ingest a peer's round-2 package; when all are in, finalize + emit.
+pub async fn process_reshare_round2<C>(
+    state: Arc<Mutex<AppState<C>>>,
+    from_device_id: String,
+    package_bytes: Vec<u8>,
+    tx: UnboundedSender<Message>,
+) where
+    C: Ciphersuite + Send + Sync + 'static,
+{
+    let ready = {
+        let mut guard = state.lock().await;
+        let session = match &guard.session {
+            Some(s) => s.clone(),
+            None => return,
+        };
+        let original = guard.reshare_original_participants.clone();
+        let sender = match reshare_identifier::<C>(&original, &from_device_id) {
+            Some(id) => id,
+            None => {
+                error!("reshare round2 from unknown device {from_device_id}");
+                return;
+            }
+        };
+        let pkg = match frost_core::keys::dkg::round2::Package::<C>::deserialize(&package_bytes) {
+            Ok(p) => p,
+            Err(e) => {
+                error!("reshare round2 deserialize: {e}");
+                return;
+            }
+        };
+        add_reshare_round2(&mut guard, sender, pkg);
+        let need = (session.total as usize).saturating_sub(1);
+        guard.reshare_round2_packages.len() >= need && need > 0
+    };
+    if ready {
+        let mut guard = state.lock().await;
+        match finalize_reshare(&mut guard) {
+            Ok((_new_key, new_pub)) => {
+                let group_hex = new_pub
+                    .verifying_key()
+                    .serialize()
+                    .map(|b| hex::encode(b))
+                    .unwrap_or_default();
+                let wallet_id = guard.reshare_wallet_id.clone().unwrap_or_default();
+                info!("✅ reshare complete; group key preserved = {}", group_hex);
+                // NOTE (#56): persist the refreshed share via
+                // Keystore::update_wallet_share once the reshare password is
+                // stashed on AppState. Until then the new share lives in-memory
+                // (AppState.key_package) — signing keeps working this session.
+                let _ = tx.send(Message::ReshareComplete { wallet_id, group_public_key: group_hex });
+            }
+            Err(e) => error!("reshare finalize: {e}"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
The networked reshare ceremony, **end-to-end and validated over real WebRTC** (the sandbox runs the loopback mesh fine — earlier deferral was over-cautious).

- `protocal/reshare.rs`: async mesh handlers mirroring `protocal::dkg` (round1 trigger/broadcast → process → part2/per-recipient round2 → finalize w/ group-key-preserved assertion → emit). Ids from the ORIGINAL set (§3); order-independent.
- `command.rs`: `StartReshare` + `ProcessReshareRound1/2`. `message.rs`: `HeadlessReshare`/`ReshareComplete`. `update.rs`: route reshare messages (replaces 4b-1 no-ops).
- `simulate.rs`: `run_reshare_e2e` — DKG → reshare on every node over the live mesh → all preserve the group key → sign with the **refreshed** shares + verify.
- `e2e_dkg.rs`: `reshare_then_sign_2_of_3` (real WebRTC).

**Verified:** reshare e2e green; full e2e 4/4; reshare unit 3/3.

Scope: **same-set** reshare (proactive rotation) reusing the post-DKG mesh. Still in #56: reduced-set (device removal → fresh announce/join), keystore persistence (password stash), CLI `reshare` one-shot + serve approve, L3 cross-process.

Refs #45 #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)