### PR TITLE
feat(reshare): cross-process networked reshare — announce/join, CLI, L3 (#56)

### DIFF
--- a/apps/cli-node/src/bridge.rs
+++ b/apps/cli-node/src/bridge.rs
@@ -158,6 +158,16 @@ impl Bridge {
                         message_hash: format!("0x{}", hex::encode(message)),
                     });
                 }
+                Message::ReshareComplete {
+                    wallet_id,
+                    group_public_key,
+                } => {
+                    events.push(CliEvent::ReshareComplete {
+                        correlates: None, // serve stamps the reshare-command id
+                        wallet_id: wallet_id.clone(),
+                        group_public_key: group_public_key.clone(),
+                    });
+                }
                 _ => {}
             }
         }

--- a/apps/cli-node/src/main.rs
+++ b/apps/cli-node/src/main.rs
@@ -52,6 +52,18 @@ enum Command {
         #[command(flatten)]
         common: OneShot,
     },
+    /// Initiate a networked share refresh/resharing of an existing wallet and
+    /// block until it completes. Announces a reshare session the retained
+    /// signers join (via `session join` / `serve`); the group address is
+    /// preserved and the refreshed share replaces the old one on disk (#56).
+    Reshare {
+        #[arg(long)]
+        wallet_id: String,
+        #[command(flatten)]
+        pw: PasswordArgs,
+        #[command(flatten)]
+        common: OneShot,
+    },
     /// Simulate a share refresh/resharing in one process and print a JSON
     /// summary (group key preserved, refreshed quorum signs, old share
     /// rejected). Self-contained — exercises the resharing engine (#45).
@@ -329,6 +341,14 @@ async fn main() -> anyhow::Result<()> {
         } => {
             let password = pw.resolve()?;
             finish(oneshot::sign(common.init_and_opts(), wallet_id, message, encoding, password).await)
+        }
+        Command::Reshare {
+            wallet_id,
+            pw,
+            common,
+        } => {
+            let password = pw.resolve()?;
+            finish(oneshot::reshare(common.init_and_opts(), wallet_id, password).await)
         }
         Command::Simulate(args) => {
             if !args.log_level.is_empty() {

--- a/apps/cli-node/src/oneshot.rs
+++ b/apps/cli-node/src/oneshot.rs
@@ -148,7 +148,40 @@ pub async fn session_join(
         label: String::new(),
     })?;
     let ev = wait_event(&mut rx, opts.timeout_secs, |e| {
-        matches!(e, CliEvent::DkgComplete { .. } | CliEvent::SignatureComplete { .. })
+        matches!(
+            e,
+            CliEvent::DkgComplete { .. }
+                | CliEvent::SignatureComplete { .. }
+                | CliEvent::ReshareComplete { .. }
+        )
+    })
+    .await?;
+    print(&ev);
+    Ok(true)
+}
+
+/// `reshare` — initiate a share refresh/resharing of an existing wallet and
+/// block until it completes. The group public key (address) is preserved; the
+/// refreshed share replaces the old one on disk. Retained co-signers approve by
+/// running `session join` (or `serve`) on the announced reshare session.
+pub async fn reshare(
+    opts: OneShotOpts,
+    wallet_id: String,
+    password: String,
+) -> anyhow::Result<bool> {
+    let (tx, mut rx) = start(&opts);
+    tx.send(Message::TriggerReconnect)?;
+    wait_event(&mut rx, 15, |e| {
+        matches!(e, CliEvent::Connection { connected: true })
+    })
+    .await?;
+    tx.send(Message::HeadlessReshare {
+        wallet_id,
+        password,
+        keystore_path: opts.keystore_path.clone(),
+    })?;
+    let ev = wait_event(&mut rx, opts.timeout_secs, |e| {
+        matches!(e, CliEvent::ReshareComplete { .. })
     })
     .await?;
     print(&ev);

--- a/apps/cli-node/src/protocol.rs
+++ b/apps/cli-node/src/protocol.rs
@@ -69,6 +69,15 @@ pub enum CliCommand {
         session_id: String,
         password: String,
     },
+    /// Initiate a networked share refresh/resharing of an existing wallet as
+    /// the owner. Announces a reshare session the retained signers join; the
+    /// group address is preserved and the refreshed share replaces the old one
+    /// on disk (#56). Co-signers approve with `join_session` on the announced
+    /// reshare session.
+    Reshare {
+        wallet_id: String,
+        password: String,
+    },
     /// Stop the runner and exit.
     Quit,
 }
@@ -149,6 +158,15 @@ pub enum CliEvent {
         total: u16,
         proposer: String,
     },
+    /// A share refresh/resharing ceremony finished. The wallet's group public
+    /// key (and therefore its address) is unchanged; the refreshed share has
+    /// been persisted, invalidating the old one (#45/#56).
+    ReshareComplete {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        correlates: Option<u64>,
+        wallet_id: String,
+        group_public_key: String,
+    },
     /// A threshold signing ceremony finished.
     SignatureComplete {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -215,6 +233,7 @@ pub fn schema_json() -> String {
             {"cmd": "join_session", "fields": {"session_id": "string", "password": "string", "label?": "string"}},
             {"cmd": "sign", "fields": {"wallet_id": "string", "message": "string", "encoding?": "utf8|hex", "password": "string"}},
             {"cmd": "approve_signing", "fields": {"session_id": "string", "password": "string"}},
+            {"cmd": "reshare", "fields": {"wallet_id": "string", "password": "string"}},
             {"cmd": "quit"},
             {"_note": "every command may include an `id` (u64); long-running ones echo it back as `correlates`"}
         ],
@@ -232,6 +251,7 @@ pub fn schema_json() -> String {
             {"event": "signing_request", "fields": {"session_id": "string", "wallet": "string", "threshold": "u16", "total": "u16", "proposer": "string"}},
             {"event": "reshare_request", "fields": {"session_id": "string", "wallet": "string", "threshold": "u16", "total": "u16", "proposer": "string"}},
             {"event": "signature_complete", "fields": {"correlates?": "u64", "signature": "string", "message_hash": "string"}},
+            {"event": "reshare_complete", "fields": {"correlates?": "u64", "wallet_id": "string", "group_public_key": "string"}},
             {"event": "error", "fields": {"correlates?": "u64", "code": "string", "message": "string"}}
         ]
     });

--- a/apps/cli-node/src/serve.rs
+++ b/apps/cli-node/src/serve.rs
@@ -66,6 +66,7 @@ pub async fn serve(opts: ServeOpts) -> anyhow::Result<()> {
     // Correlate the next terminal event with the command that started it.
     let pending_create: Arc<Mutex<Option<u64>>> = Arc::new(Mutex::new(None));
     let pending_sign: Arc<Mutex<Option<u64>>> = Arc::new(Mutex::new(None));
+    let pending_reshare: Arc<Mutex<Option<u64>>> = Arc::new(Mutex::new(None));
 
     // --- runner sync closure: model/message → events + snapshot cache ---
     let out_for_sync = out_tx.clone();
@@ -73,6 +74,7 @@ pub async fn serve(opts: ServeOpts) -> anyhow::Result<()> {
     let snapshot_for_sync = snapshot.clone();
     let pending_for_sync = pending_create.clone();
     let pending_sign_for_sync = pending_sign.clone();
+    let pending_reshare_for_sync = pending_reshare.clone();
     // Auto-approve plumbing: the callback can't capture the runner sender
     // (chicken-and-egg with spawn), so route it through a OnceLock set right
     // after spawn returns.
@@ -101,6 +103,9 @@ pub async fn serve(opts: ServeOpts) -> anyhow::Result<()> {
                     CliEvent::SignatureComplete { correlates, .. } if correlates.is_none() => {
                         *correlates = pending_sign_for_sync.lock().unwrap().take();
                     }
+                    CliEvent::ReshareComplete { correlates, .. } if correlates.is_none() => {
+                        *correlates = pending_reshare_for_sync.lock().unwrap().take();
+                    }
                     // Policy-gated auto-approval: join the signing session to
                     // contribute our share, only if the operator opted in AND
                     // the request passes the policy (allowlist + budget).
@@ -117,6 +122,27 @@ pub async fn serve(opts: ServeOpts) -> anyhow::Result<()> {
                                     code: "auto_approved".into(),
                                     message: format!(
                                         "auto-approved signing request for {wallet} ({session_id})"
+                                    ),
+                                });
+                            }
+                        }
+                    }
+                    // Reshare is approved the same way a co-signer approves
+                    // signing — by joining the session to contribute a refreshed
+                    // share. Gate on the same policy (allowlist + budget).
+                    CliEvent::ReshareRequest { session_id, wallet, .. } => {
+                        if policy.try_approve(wallet) {
+                            if let Some(tx) = approve_sender_cb.get() {
+                                let _ = tx.send(Message::HeadlessJoinSession {
+                                    session_id: session_id.clone(),
+                                    password: approve_pw.clone(),
+                                    label: String::new(),
+                                });
+                                let _ = out_for_sync.send(CliEvent::Error {
+                                    correlates: None,
+                                    code: "auto_approved".into(),
+                                    message: format!(
+                                        "auto-approved reshare request for {wallet} ({session_id})"
                                     ),
                                 });
                             }
@@ -268,6 +294,21 @@ pub async fn serve(opts: ServeOpts) -> anyhow::Result<()> {
                     session_id,
                     password,
                     label: String::new(),
+                });
+                ack(id);
+            }
+            CliCommand::Reshare {
+                wallet_id,
+                password,
+            } => {
+                // Initiator: load the OLD share + announce a reshare session.
+                // Retained signers approve with `join_session`. Correlate the
+                // eventual `reshare_complete` with this command id.
+                *pending_reshare.lock().unwrap() = id;
+                let _ = runner_tx.send(Message::HeadlessReshare {
+                    wallet_id,
+                    password,
+                    keystore_path: opts.keystore_path.clone(),
                 });
                 ack(id);
             }

--- a/apps/cli-node/src/simulate.rs
+++ b/apps/cli-node/src/simulate.rs
@@ -78,7 +78,7 @@ impl SigningResult {
 #[derive(Debug, Clone)]
 enum Evt {
     Connected,
-    SessionDiscovered { id: String, signing: bool },
+    SessionDiscovered { id: String, signing: bool, reshare: bool },
     DkgDone { wallet_id: String, group_key: String },
     SignDone { signature: String, message: String },
     ReshareDone { group_key: String },
@@ -100,6 +100,7 @@ fn watcher() -> (
                     let _ = tx.send(Evt::SessionDiscovered {
                         id: session.session_id.clone(),
                         signing: matches!(session.session_type, SessionType::Signing { .. }),
+                        reshare: matches!(session.session_type, SessionType::Reshare { .. }),
                     });
                 }
                 Message::DKGFinalized {
@@ -416,24 +417,75 @@ pub async fn run_reshare_e2e(opts: SimulateOpts, message: &str) -> anyhow::Resul
     let nodes = opts.nodes;
     let threshold = opts.threshold;
     let started = Instant::now();
-    let mut c = dkg_cluster(&opts).await?;
+    let c = dkg_cluster(&opts).await?;
     if !c.agreed {
         anyhow::bail!("DKG did not agree; aborting reshare");
     }
     let dkg_group_key = c.group_key.clone();
     let wallet_id = c.outcomes[0].wallet_id.clone();
 
-    // Trigger a reshare on every node — each refreshes its share over the mesh.
-    for (i, s) in c.senders.iter().enumerate() {
-        s.send(Message::HeadlessReshare {
-            wallet_id: wallet_id.clone(),
+    // True cross-process reshare (#56): tear down the DKG runners and spawn FRESH
+    // ones against the SAME keystores. Each fresh node loads its OLD share from
+    // disk, the initiator announces a reshare session, the retained signers
+    // discover + join, a NEW mesh forms, and every node refreshes. This
+    // exercises the disk-load + announce/join path a separate device would take
+    // — not the in-memory post-DKG mesh shortcut (4b).
+    //
+    // The fresh runners reuse the ORIGINAL device_ids (reshare identifiers are
+    // canonical over the original set, design §3) so they connect to a FRESH
+    // embedded signal server — the old runners still hold those ids on the old
+    // server (the server rejects duplicate live registrations, exactly as it
+    // would for a real still-connected device).
+    let ws_url = match &opts.signal_url {
+        Some(u) => u.clone(),
+        None => embedded_signal_server().await?,
+    };
+    let device_ids = c.device_ids.clone();
+    let keystores = c.keystores; // move: must outlive the fresh runners
+    drop(c.senders);
+    drop(c.receivers);
+
+    let mut senders = Vec::new();
+    let mut receivers = Vec::new();
+    for (i, device_id) in device_ids.iter().enumerate() {
+        let (cb, rx) = watcher();
+        let ks_path = keystores[i].path().to_string_lossy().into_owned();
+        let tx = if opts.curve == "ed25519" {
+            spawn_ed25519(device_id.clone(), ks_path, ws_url.clone(), cb)
+        } else {
+            spawn_secp256k1(device_id.clone(), ks_path, ws_url.clone(), cb)
+        };
+        senders.push(tx);
+        receivers.push(rx);
+    }
+    for tx in &senders {
+        let _ = tx.send(Message::TriggerReconnect);
+    }
+    for rx in &mut receivers {
+        wait_for(rx, 15, |e| matches!(e, Evt::Connected)).await?;
+    }
+
+    // Initiator (node 0) announces the reshare; retained signers 1.. join it.
+    senders[0].send(Message::HeadlessReshare {
+        wallet_id: wallet_id.clone(),
+        password: "sim-password-0".into(),
+        keystore_path: keystores[0].path().to_string_lossy().to_string(),
+    })?;
+    for (i, rx) in receivers.iter_mut().enumerate().skip(1) {
+        let session_id = match wait_for(rx, 20, |e| matches!(e, Evt::SessionDiscovered { reshare: true, .. })).await? {
+            Evt::SessionDiscovered { id, .. } => id,
+            _ => unreachable!(),
+        };
+        senders[i].send(Message::HeadlessJoinSession {
+            session_id,
             password: format!("sim-password-{i}"),
-            keystore_path: c.keystores[i].path().to_string_lossy().to_string(),
+            label: "reshare".into(),
         })?;
     }
+
     // Every node must report reshare completion with the unchanged group key.
     let mut reshare_keys = Vec::new();
-    for rx in c.receivers.iter_mut() {
+    for rx in receivers.iter_mut() {
         let done = wait_for(rx, opts.timeout_secs, |e| matches!(e, Evt::ReshareDone { .. })).await?;
         if let Evt::ReshareDone { group_key } = done {
             reshare_keys.push(group_key);
@@ -447,7 +499,7 @@ pub async fn run_reshare_e2e(opts: SimulateOpts, message: &str) -> anyhow::Resul
     // group key (a fresh Keystore reads from the file we just rewrote).
     let persisted_group_key = {
         use tui_node::keystore::Keystore;
-        Keystore::new(c.keystores[0].path(), &c.device_ids[0])
+        Keystore::new(keystores[0].path(), &device_ids[0])
             .ok()
             .and_then(|ks| ks.get_wallet(&wallet_id).map(|w| w.group_public_key.clone()))
             .unwrap_or_default()
@@ -456,8 +508,8 @@ pub async fn run_reshare_e2e(opts: SimulateOpts, message: &str) -> anyhow::Resul
 
     // Sign with the REFRESHED shares and verify against the (unchanged) group key.
     let (signature, signed_message) = drive_signing(
-        &c.senders,
-        &mut c.receivers,
+        &senders,
+        &mut receivers,
         wallet_id,
         message,
         "utf8",

--- a/apps/cli-node/src/simulate.rs
+++ b/apps/cli-node/src/simulate.rs
@@ -442,8 +442,20 @@ pub async fn run_reshare_e2e(opts: SimulateOpts, message: &str) -> anyhow::Resul
     };
     let device_ids = c.device_ids.clone();
     let keystores = c.keystores; // move: must outlive the fresh runners
+
+    // Tear the DKG cluster DOWN before bringing the reshare cluster up: send
+    // Quit so each runner exits its loop and drops its `AppState` (closing the
+    // WebRTC peer connections + releasing their ICE/UDP sockets), then drop the
+    // handles and give the runtime a beat to reclaim those sockets. Without this
+    // the DKG cluster's ~N WebRTC agents stay alive alongside the reshare
+    // cluster's, and across a sequential e2e suite the accumulated ICE agents
+    // exhaust loopback sockets → "WebRTC connection FAILED" in the reshare mesh.
+    for tx in &c.senders {
+        let _ = tx.send(Message::Quit);
+    }
     drop(c.senders);
     drop(c.receivers);
+    tokio::time::sleep(Duration::from_secs(2)).await;
 
     let mut senders = Vec::new();
     let mut receivers = Vec::new();

--- a/apps/cli-node/tests/l3_serve_process.rs
+++ b/apps/cli-node/tests/l3_serve_process.rs
@@ -418,3 +418,90 @@ async fn sign_after_process_restart_verifies() {
     a.quit().await;
     b.quit().await;
 }
+
+/// RESHARE-L3 (#56): a full networked share refresh across two REAL `serve`
+/// processes, then a signature with the REFRESHED shares. After DKG we KILL both
+/// processes and bring fresh ones up on the SAME keystores — so the reshare runs
+/// over a brand-new mesh, each node loading its OLD share from disk (exactly what
+/// a separate device does). The group public key (address) must survive the
+/// refresh, and a 2-of-2 signature with the new shares must verify against it.
+///
+/// This is the cross-process counterpart to the in-process `reshare_then_sign`
+/// e2e: it exercises the actual compiled binary's `reshare` / `reshare_request`
+/// / `reshare_complete` JSONL surface and the announce/join ceremony end to end.
+#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+#[ignore = "spawns serve processes + real WebRTC over loopback; run with --ignored"]
+async fn reshare_then_sign_across_serve_processes() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(webrtc_signal_server::run(listener));
+    let ws_url = format!("ws://127.0.0.1:{port}");
+
+    let ks_a = tempfile::TempDir::new().unwrap();
+    let ks_b = tempfile::TempDir::new().unwrap();
+    let pa = ks_a.path().to_string_lossy().to_string();
+    let pb = ks_b.path().to_string_lossy().to_string();
+
+    // --- Phase 1: DKG, then kill both processes (shares persist to disk). ---
+    let (wallet_id, group_key) = {
+        let mut a = spawn_connected("reshare-a", &pa, &ws_url).await.expect("a");
+        let mut b = spawn_connected("reshare-b", &pb, &ws_url).await.expect("b");
+        let r = dkg_2of2(&mut a, &mut b).await.expect("dkg");
+        a.quit().await;
+        b.quit().await;
+        r
+    };
+    assert!(!group_key.is_empty());
+    // Give the server a moment to drop the closed connections before reuse.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // --- Phase 2: fresh processes on the SAME keystores, then reshare. ---
+    let mut a = spawn_connected("reshare-a", &pa, &ws_url).await.expect("a restart");
+    let mut b = spawn_connected("reshare-b", &pb, &ws_url).await.expect("b restart");
+
+    // a initiates the reshare (loads its OLD share, announces a reshare session).
+    a.send(json!({"id": 20, "cmd": "reshare", "wallet_id": wallet_id, "password": "pw-a"}))
+        .await
+        .unwrap();
+
+    // b discovers the reshare request and approves by joining (contributing a
+    // refreshed share). `join_session` is the reshare approval path.
+    let req = b.wait_for("reshare_request", 30).await.expect("b reshare_request");
+    let sid = req["session_id"].as_str().unwrap().to_string();
+    b.send(json!({"id": 21, "cmd": "join_session", "session_id": sid, "password": "pw-b"}))
+        .await
+        .unwrap();
+
+    // Both nodes complete the refresh; the group key (address) must be unchanged.
+    let rc_a = a.wait_for("reshare_complete", 90).await.expect("a reshare_complete");
+    let _rc_b = b.wait_for("reshare_complete", 90).await.expect("b reshare_complete");
+    assert_eq!(
+        rc_a["group_public_key"].as_str().unwrap(),
+        group_key,
+        "group key changed across reshare"
+    );
+
+    // --- Phase 3: sign with the REFRESHED shares; must verify. ---
+    a.send(json!({
+        "id": 30, "cmd": "sign", "wallet_id": wallet_id,
+        "message": "signed after a networked reshare", "encoding": "utf8", "password": "pw-a"
+    }))
+    .await
+    .unwrap();
+    let req = b.wait_for("signing_request", 30).await.expect("b signing_request");
+    let sid = req["session_id"].as_str().unwrap().to_string();
+    b.send(json!({"id": 31, "cmd": "approve_signing", "session_id": sid, "password": "pw-b"}))
+        .await
+        .unwrap();
+    let sc = a.wait_for("signature_complete", 90).await.expect("a signature_complete");
+    let sig = sc["signature"].as_str().unwrap();
+    let msg = sc["message_hash"].as_str().unwrap();
+    assert!(
+        verify_secp256k1(&group_key, msg, sig),
+        "post-reshare signature failed to verify: sig={sig} msg={msg} group={group_key}"
+    );
+    eprintln!("✅ RESHARE-L3: reshared across processes, group preserved, refreshed shares signed");
+
+    a.quit().await;
+    b.quit().await;
+}

--- a/apps/tui-node/src/elm/command.rs
+++ b/apps/tui-node/src/elm/command.rs
@@ -59,9 +59,26 @@ pub enum Command {
     /// Calls `protocal::dkg::process_dkg_round2` which finalises the key with
     /// `part3` once all Round 2 packages for us have arrived.
     ProcessDKGRound2 { from_device: String, package_bytes: Vec<u8> },
-    /// Begin a same-set reshare on this node (#45): refresh part 1 over the
-    /// current session's live mesh, then broadcast. Triggered by HeadlessReshare.
+    /// Reshare **initiator** (#56): load the OLD share from the keystore, seed
+    /// the reshare context, and announce a `SessionType::Reshare` session. The
+    /// refresh itself fires later via the shared mesh-ready path
+    /// (`StartFrostProtocol`), exactly like DKG. Triggered by `HeadlessReshare`.
     StartReshare { wallet_id: String, password: String, keystore_path: String },
+    /// Reshare **joiner** (#56): load the OLD share, seed the reshare context,
+    /// and send a `SessionStatusUpdate` to join the announced reshare session so
+    /// the mesh forms. Refresh fires via `StartFrostProtocol`. Dispatched from
+    /// the SubmitPassword `Reshare` arm once the joiner accepts the invite.
+    JoinReshare {
+        session_id: String,
+        wallet_name: String,
+        total: u16,
+        threshold: u16,
+        proposer_id: String,
+        curve_type: String,
+        group_public_key: String,
+        password: String,
+        keystore_path: String,
+    },
     /// Process a peer's reshare round-1 / round-2 package received over a data
     /// channel — drives `protocal::reshare`.
     ProcessReshareRound1 { from_device: String, package_bytes: Vec<u8> },
@@ -246,6 +263,58 @@ pub(crate) fn decode_keystore_blob<C: frost_core::Ciphersuite>(
     Ok((kp, pkp))
 }
 
+/// Load an existing wallet's OLD share + metadata from the keystore and seed the
+/// reshare context on `AppState` (keys, ORIGINAL participant set, persist creds,
+/// `reshare_in_progress`). Shared by the reshare initiator (`StartReshare`) and
+/// joiner (`JoinReshare`) so that — before the mesh forms and the refresh runs —
+/// finalize has the old `KeyPackage` and the ORIGINAL identifier set (design §3,
+/// never the retained/mesh set).
+///
+/// Returns `(original_participants, threshold, total_participants, curve_type,
+/// group_public_key)` from the persisted metadata, for the announce/join. On any
+/// failure returns `Err` and leaves `AppState` untouched (no `reshare_in_progress`).
+#[allow(clippy::type_complexity)]
+async fn seed_reshare_context<C: frost_core::Ciphersuite>(
+    app_state: &std::sync::Arc<tokio::sync::Mutex<crate::utils::appstate_compat::AppState<C>>>,
+    wallet_id: &str,
+    password: &str,
+    keystore_path: &str,
+) -> Result<(Vec<String>, u16, u16, String, String), String> {
+    use crate::keystore::Keystore;
+    let device_id = { app_state.lock().await.device_id.clone() };
+    let ks = Keystore::new(keystore_path, &device_id)
+        .map_err(|e| format!("reshare: keystore open ({keystore_path}): {e}"))?;
+    let meta = ks
+        .get_wallet(wallet_id)
+        .ok_or_else(|| format!("reshare: wallet '{wallet_id}' not found in keystore"))?
+        .clone();
+    let blob = ks
+        .load_wallet_file(wallet_id, password)
+        .map_err(|e| format!("reshare: unlock '{wallet_id}' failed: {e}"))?;
+    let (key_package, public_key_package) =
+        decode_keystore_blob::<C>(&blob).map_err(|e| format!("reshare: decode blob: {e}"))?;
+
+    let mut state = app_state.lock().await;
+    state.key_package = Some(key_package);
+    state.group_public_key = Some(*public_key_package.verifying_key());
+    state.public_key_package = Some(public_key_package);
+    state.current_wallet_id = Some(wallet_id.to_string());
+    // ORIGINAL participant set (design §3) — survivors keep their original FROST
+    // ids even when a device is removed, so we always canonicalise over this.
+    state.reshare_original_participants = meta.participants.clone();
+    state.reshare_wallet_id = Some(wallet_id.to_string());
+    state.reshare_password = Some(password.to_string());
+    state.reshare_keystore_path = Some(keystore_path.to_string());
+    state.reshare_in_progress = true;
+    Ok((
+        meta.participants.clone(),
+        meta.threshold,
+        meta.total_participants,
+        meta.curve_type.clone(),
+        meta.group_public_key.clone(),
+    ))
+}
+
 /// Parse a `session_info` JSON blob (as sent over the wire by the Cloudflare
 /// signal Worker) into a strongly-typed `SessionInfo`. Returns `None` if any
 /// of the required scalar fields is missing or has the wrong type — callers
@@ -291,15 +360,35 @@ pub(crate) fn parse_session_info(
         .unwrap_or("Network")
         .to_string();
 
-    // `session_type` on the wire is a flat string flag: `"dkg"` or
-    // `"signing"`. For signing sessions we also carry `wallet_name` and
-    // `group_public_key` in the announcement JSON so joiners can
-    // cross-check against their local keystore without a separate query.
+    // `session_type` on the wire is a flat string flag: `"dkg"`,
+    // `"signing"`, or `"reshare"`. For signing/reshare sessions we also carry
+    // `wallet_name` and `group_public_key` in the announcement JSON so joiners
+    // can cross-check against their local keystore without a separate query.
     let session_type_tag = session_info
         .get("session_type")
         .and_then(|v| v.as_str())
         .unwrap_or("dkg");
-    let session_type = if session_type_tag == "signing" {
+    let session_type = if session_type_tag == "reshare" {
+        // Reshare announce: the joiner needs `wallet_name` to know which local
+        // wallet to unlock, and `group_public_key` to confirm it owns that
+        // exact wallet before refreshing. Degrade to empty strings if absent —
+        // downstream matches care about the variant shape.
+        let wallet_name = session_info
+            .get("wallet_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let group_public_key = session_info
+            .get("group_public_key")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        SessionType::Reshare {
+            wallet_name,
+            curve_type: curve_type.clone(),
+            group_public_key,
+        }
+    } else if session_type_tag == "signing" {
         // Degrade gracefully: if the signing-specific fields aren't
         // present we still produce a Signing variant with empty
         // strings, since the downstream matches care about the variant
@@ -777,7 +866,7 @@ impl Command {
                 // twice would regenerate the secret/package and break the
                 // protocol mid-flight. We atomically transition dkg_state to
                 // `Round1InProgress` only from `Idle` — subsequent calls bail.
-                let (device_id, internal_cmd_tx, have_session, already_running) = {
+                let (device_id, internal_cmd_tx, have_session, already_running, is_reshare) = {
                     let mut state_guard = app_state.lock().await;
                     let already = !matches!(state_guard.dkg_state, crate::utils::state::DkgState::Idle);
                     if !already {
@@ -788,6 +877,7 @@ impl Command {
                         state_guard.websocket_internal_cmd_tx.clone(),
                         state_guard.session.is_some(),
                         already,
+                        state_guard.reshare_in_progress,
                     )
                 };
                 if already_running {
@@ -803,6 +893,30 @@ impl Command {
                     state.dkg_state = crate::utils::state::DkgState::Idle;
                     return Ok(());
                 }
+
+                // Reshare fork: the mesh-ready path is identical for DKG and
+                // reshare (announce → join → mesh → StartFrostProtocol). The only
+                // difference is which FROST ceremony runs. When the initiator
+                // (`StartReshare`) / joiner (`JoinReshare`) seeded a reshare,
+                // `reshare_in_progress` is set — refresh the share instead of
+                // generating a fresh key. (The OLD share + ORIGINAL participant
+                // set were loaded from the keystore by those commands.)
+                if is_reshare {
+                    info!(
+                        "🔄 Triggering FROST reshare Round 1 for device_id={}",
+                        device_id
+                    );
+                    crate::protocal::reshare::handle_trigger_reshare_round1(
+                        app_state.clone(),
+                        device_id.clone(),
+                    )
+                    .await;
+                    let _ = tx.send(Message::Info {
+                        message: "✅ Reshare Round 1 initiated - refreshing share...".to_string(),
+                    });
+                    return Ok(());
+                }
+
                 let internal_tx = internal_cmd_tx.unwrap_or_else(|| {
                     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
                     tx
@@ -862,23 +976,190 @@ impl Command {
             }
 
             Command::StartReshare { wallet_id, password, keystore_path } => {
-                // Same-set reshare reusing the current session's live mesh (#45).
-                // Seed the reshare context (id source + persist creds) from the
-                // active session, then trigger round 1 on this node.
-                let self_id = {
-                    let mut state = app_state.lock().await;
-                    if let Some(session) = state.session.clone() {
-                        if state.reshare_original_participants.is_empty() {
-                            state.reshare_original_participants = session.participants.clone();
+                // Reshare INITIATOR (#56). Mirrors `StartDKG`: load the OLD share
+                // from the keystore, seed the reshare context, then announce a
+                // `SessionType::Reshare` session so the retained signers can
+                // discover + join. The refresh itself does NOT run here — it
+                // fires on every node via the shared mesh-ready path
+                // (`StartFrostProtocol`, which forks on `reshare_in_progress`),
+                // exactly like DKG Round 1.
+                info!("Reshare initiator: load '{}' + announce reshare session", wallet_id);
+                let (orig_participants, threshold, total, curve_type, group_pk) =
+                    match seed_reshare_context::<C>(app_state, &wallet_id, &password, &keystore_path)
+                        .await
+                    {
+                        Ok(v) => v,
+                        Err(e) => {
+                            error!("{e}");
+                            let _ = tx.send(Message::Error { message: e });
+                            return Ok(());
+                        }
+                    };
+                drop(password);
+
+                // Same-set reshare: retain ALL original participants. (Reduced-set
+                // / device-removal threads a keep-list in a follow-up; the §3
+                // identifier logic + finalize already support non-contiguous ids.)
+                let retained_total = if total as usize == orig_participants.len() && total > 0 {
+                    total
+                } else {
+                    orig_participants.len() as u16
+                };
+
+                let device_id = { app_state.lock().await.device_id.clone() };
+                let ws_tx = {
+                    let state = app_state.lock().await;
+                    match state.websocket_msg_tx.clone() {
+                        Some(ws) => ws,
+                        None => {
+                            warn!("StartReshare: primary WebSocket not up — can't announce");
+                            let _ = tx.send(Message::Error {
+                                message: "Signal server not connected. Wait for reconnect."
+                                    .to_string(),
+                            });
+                            let mut s = app_state.lock().await;
+                            crate::protocal::reshare::clear_reshare_state(&mut s);
+                            return Ok(());
                         }
                     }
-                    state.reshare_wallet_id = Some(wallet_id);
-                    state.reshare_password = Some(password);
-                    state.reshare_keystore_path = Some(keystore_path);
-                    state.device_id.clone()
                 };
-                crate::protocal::reshare::handle_trigger_reshare_round1(app_state.clone(), self_id)
-                    .await;
+
+                let session_id = format!("reshare_{}", uuid::Uuid::new_v4());
+                let announce = webrtc_signal_server::ClientMsg::AnnounceSession {
+                    session_info: serde_json::json!({
+                        "session_id": session_id.clone(),
+                        "total": retained_total,
+                        "threshold": threshold,
+                        "session_type": "reshare",
+                        "proposer_id": device_id.clone(),
+                        "participants": [device_id.clone()],
+                        "curve_type": curve_type.clone(),
+                        "coordination_type": "Network",
+                        "wallet_name": wallet_id.clone(),
+                        "group_public_key": group_pk.clone(),
+                    }),
+                };
+                match serde_json::to_string(&announce) {
+                    Ok(json) => {
+                        info!("Announcing reshare session: {}", json);
+                        if ws_tx.send(json).is_err() {
+                            let _ = tx.send(Message::Error {
+                                message: "Primary WebSocket closed mid reshare-announce".to_string(),
+                            });
+                        }
+                    }
+                    Err(e) => error!("Serialize reshare AnnounceSession failed: {}", e),
+                }
+
+                {
+                    let mut state = app_state.lock().await;
+                    state.session = Some(crate::protocal::signal::SessionInfo {
+                        session_id: session_id.clone(),
+                        proposer_id: device_id.clone(),
+                        participants: vec![device_id.clone()],
+                        threshold,
+                        total: retained_total,
+                        session_type: crate::protocal::signal::SessionType::Reshare {
+                            wallet_name: wallet_id.clone(),
+                            curve_type: curve_type.clone(),
+                            group_public_key: group_pk.clone(),
+                        },
+                        curve_type,
+                        coordination_type: "Network".to_string(),
+                        signing_message_hex: None,
+                    });
+                }
+                let _ = tx.send(Message::Info {
+                    message: format!("🔄 Reshare session announced: {} — waiting for signers", session_id),
+                });
+            }
+
+            Command::JoinReshare {
+                session_id,
+                wallet_name,
+                total,
+                threshold,
+                proposer_id,
+                curve_type,
+                group_public_key,
+                password,
+                keystore_path,
+            } => {
+                // Reshare JOINER (#56). Mirrors `JoinDKG`: load the OLD share,
+                // seed the reshare context, then send a `SessionStatusUpdate` so
+                // the server+initiator grow the participant set and the mesh
+                // forms. Refresh fires via the shared `StartFrostProtocol` path.
+                info!("Reshare joiner: load '{}' + join session {}", wallet_name, session_id);
+                if let Err(e) =
+                    seed_reshare_context::<C>(app_state, &wallet_name, &password, &keystore_path)
+                        .await
+                {
+                    error!("{e}");
+                    let _ = tx.send(Message::Error { message: e });
+                    return Ok(());
+                }
+                drop(password);
+
+                let device_id = { app_state.lock().await.device_id.clone() };
+                let ws_tx = {
+                    let state = app_state.lock().await;
+                    match state.websocket_msg_tx.clone() {
+                        Some(ws) => ws,
+                        None => {
+                            warn!("JoinReshare: primary WebSocket not up — can't join");
+                            let _ = tx.send(Message::Error {
+                                message: "Signal server not connected. Wait for reconnect."
+                                    .to_string(),
+                            });
+                            let mut s = app_state.lock().await;
+                            crate::protocal::reshare::clear_reshare_state(&mut s);
+                            return Ok(());
+                        }
+                    }
+                };
+
+                let status_msg = webrtc_signal_server::ClientMsg::SessionStatusUpdate {
+                    session_info: serde_json::json!({
+                        "session_id": session_id.clone(),
+                        "participant_joined": device_id.clone(),
+                    }),
+                };
+                match serde_json::to_string(&status_msg) {
+                    Ok(json) => {
+                        if ws_tx.send(json).is_err() {
+                            let _ = tx.send(Message::Error {
+                                message: "Primary WS closed mid reshare-join".to_string(),
+                            });
+                        }
+                    }
+                    Err(e) => error!("Serialize reshare SessionStatusUpdate: {}", e),
+                }
+
+                {
+                    let mut state = app_state.lock().await;
+                    state.session = Some(crate::protocal::signal::SessionInfo {
+                        session_id: session_id.clone(),
+                        proposer_id: if proposer_id.is_empty() {
+                            "unknown".to_string()
+                        } else {
+                            proposer_id
+                        },
+                        participants: vec![device_id.clone()],
+                        threshold,
+                        total,
+                        session_type: crate::protocal::signal::SessionType::Reshare {
+                            wallet_name,
+                            curve_type: curve_type.clone(),
+                            group_public_key,
+                        },
+                        curve_type,
+                        coordination_type: "Network".to_string(),
+                        signing_message_hex: None,
+                    });
+                }
+                let _ = tx.send(Message::Info {
+                    message: format!("🔄 Joined reshare session: {}", session_id),
+                });
             }
 
             Command::ProcessReshareRound1 {

--- a/apps/tui-node/src/elm/command.rs
+++ b/apps/tui-node/src/elm/command.rs
@@ -866,7 +866,7 @@ impl Command {
                 // twice would regenerate the secret/package and break the
                 // protocol mid-flight. We atomically transition dkg_state to
                 // `Round1InProgress` only from `Idle` — subsequent calls bail.
-                let (device_id, internal_cmd_tx, have_session, already_running, is_reshare) = {
+                let (device_id, internal_cmd_tx, have_session, already_running, is_reshare, dkg_in_progress) = {
                     let mut state_guard = app_state.lock().await;
                     let already = !matches!(state_guard.dkg_state, crate::utils::state::DkgState::Idle);
                     if !already {
@@ -878,6 +878,7 @@ impl Command {
                         state_guard.session.is_some(),
                         already,
                         state_guard.reshare_in_progress,
+                        state_guard.dkg_in_progress,
                     )
                 };
                 if already_running {
@@ -889,6 +890,26 @@ impl Command {
                         "StartFrostProtocol fired but AppState::session is None — ignoring"
                     );
                     // Roll back the state transition since we didn't actually run.
+                    let mut state = app_state.lock().await;
+                    state.dkg_state = crate::utils::state::DkgState::Idle;
+                    return Ok(());
+                }
+                // Guard against a STALE-session mesh: when a node reconnects to a
+                // signal server that still lists a previously-completed session
+                // (e.g. after a process restart), that session's mesh can re-form
+                // and fire mesh-ready even though this node has NO active ceremony
+                // intent. Running DKG Round 1 then would (a) waste a ceremony and
+                // (b) pin `dkg_state` to Round1InProgress, blocking a subsequent
+                // *reshare* on the same node (its StartFrostProtocol would be
+                // ignored as "already running"). Only proceed when a ceremony is
+                // genuinely pending: a reshare (`reshare_in_progress`) or a DKG
+                // (`dkg_in_progress`, set by StartDKG/JoinDKG). Signing is immune —
+                // it never routes through this path.
+                if !is_reshare && !dkg_in_progress {
+                    warn!(
+                        "StartFrostProtocol fired with no DKG/reshare in progress \
+                         (stale-session mesh?) — ignoring"
+                    );
                     let mut state = app_state.lock().await;
                     state.dkg_state = crate::utils::state::DkgState::Idle;
                     return Ok(());
@@ -909,6 +930,7 @@ impl Command {
                     crate::protocal::reshare::handle_trigger_reshare_round1(
                         app_state.clone(),
                         device_id.clone(),
+                        tx.clone(),
                     )
                     .await;
                     let _ = tx.send(Message::Info {
@@ -1170,6 +1192,7 @@ impl Command {
                     app_state.clone(),
                     from_device,
                     package_bytes,
+                    tx.clone(),
                 )
                 .await;
             }

--- a/apps/tui-node/src/elm/update.rs
+++ b/apps/tui-node/src/elm/update.rs
@@ -580,18 +580,48 @@ pub fn update(model: &mut Model, msg: Message) -> Option<Command> {
                                 .clone(),
                         })
                     }
-                    crate::protocal::signal::SessionType::Reshare { wallet_name, .. } => {
-                        // Phase 2 (#45): the Reshare session type exists, but the
-                        // joiner ceremony (unlock → JoinReshare over the mesh) is
-                        // wired in a later phase. Don't silently no-op into a
-                        // confusing state — clear the pending password and warn.
-                        warn!(
+                    crate::protocal::signal::SessionType::Reshare {
+                        wallet_name,
+                        curve_type,
+                        group_public_key,
+                    } => {
+                        // Reshare joiner (#56): the user accepted a reshare invite
+                        // and supplied the wallet password. Reuse the DKG progress
+                        // screen (the mesh-formation UX is identical) and dispatch
+                        // `JoinReshare`, which loads the OLD share, seeds the
+                        // reshare context, and joins so the mesh forms. The refresh
+                        // then fires via the shared `StartFrostProtocol` path.
+                        let password = model
+                            .wallet_state
+                            .pending_password
+                            .take()
+                            .unwrap_or_default();
+                        info!(
                             "SubmitPassword on reshare session {} (wallet '{}') — \
-                             reshare ceremony not yet wired; ignoring",
+                             dispatching JoinReshare",
                             session_id, wallet_name
                         );
-                        model.wallet_state.pending_password = None;
-                        None
+                        model.push_screen(Screen::DKGProgress {
+                            session_id: session_id.clone(),
+                        });
+                        model.ui_state.focus =
+                            crate::elm::model::ComponentId::DKGProgress;
+                        model
+                            .ui_state
+                            .selected_indices
+                            .entry(crate::elm::model::ComponentId::DKGProgress)
+                            .or_insert(0);
+                        Some(Command::JoinReshare {
+                            session_id,
+                            wallet_name: wallet_name.clone(),
+                            total: session.total,
+                            threshold: session.threshold,
+                            proposer_id: session.proposer_id.clone(),
+                            curve_type: curve_type.clone(),
+                            group_public_key: group_public_key.clone(),
+                            password,
+                            keystore_path: model.wallet_state.keystore_path.clone(),
+                        })
                     }
                 }
             } else if let Some(cw) = model.wallet_state.creating_wallet.clone() {

--- a/apps/tui-node/src/protocal/reshare.rs
+++ b/apps/tui-node/src/protocal/reshare.rs
@@ -187,9 +187,14 @@ fn b64(bytes: &[u8]) -> String {
 }
 
 /// Begin a reshare on this node: refresh part 1 over the current session/mesh,
-/// then broadcast our round-1 package to the retained peers.
-pub async fn handle_trigger_reshare_round1<C>(state: Arc<Mutex<AppState<C>>>, self_device_id: String)
-where
+/// then broadcast our round-1 package to the retained peers. If peers' round-1
+/// packages already arrived (faster transport, or they triggered first), advance
+/// to round 2 immediately now that our own round-1 secret exists.
+pub async fn handle_trigger_reshare_round1<C>(
+    state: Arc<Mutex<AppState<C>>>,
+    self_device_id: String,
+    tx: UnboundedSender<Message>,
+) where
     C: Ciphersuite + Send + Sync + 'static,
 {
     let (participants, pkg_bytes) = {
@@ -234,17 +239,19 @@ where
         let _ = crate::utils::device::send_webrtc_message(peer, &msg, state.clone()).await;
     }
     info!("📡 reshare round-1 broadcast to {} peers", participants.len().saturating_sub(1));
+    maybe_advance_to_reshare_round2(state, self_device_id, tx).await;
 }
 
-/// Ingest a peer's round-1 package; when all peers' are in, advance to round 2.
+/// Ingest a peer's round-1 package, then try to advance to round 2.
 pub async fn process_reshare_round1<C>(
     state: Arc<Mutex<AppState<C>>>,
     from_device_id: String,
     package_bytes: Vec<u8>,
+    tx: UnboundedSender<Message>,
 ) where
     C: Ciphersuite + Send + Sync + 'static,
 {
-    let advance = {
+    {
         let mut guard = state.lock().await;
         let session = match &guard.session {
             Some(s) => s.clone(),
@@ -271,18 +278,49 @@ pub async fn process_reshare_round1<C>(
             }
         };
         add_reshare_round1(&mut guard, sender, pkg);
-        let need = (session.total as usize).saturating_sub(1);
-        guard.reshare_round1_packages.len() >= need && need > 0
+    }
+    let self_id = state.lock().await.device_id.clone();
+    maybe_advance_to_reshare_round2(state, self_id, tx).await;
+}
+
+/// Advance to round 2 iff (a) our OWN round-1 secret exists — i.e. our local
+/// round-1 has run — AND (b) all retained peers' round-1 packages are in. Safe
+/// to call from either the local trigger or a peer-package handler. Gating on
+/// the secret is essential: a peer's round-1 can land before our own round-1 ran
+/// (observed across separate processes on a fresh mesh), and `reshare_part2`
+/// consumes that secret — advancing without it aborts with "no round-1 secret".
+/// (DKG sidesteps this because its round-1 map includes our own package; the
+/// reshare map holds peers only, so "all peers in" ≠ "we ran".)
+async fn maybe_advance_to_reshare_round2<C>(
+    state: Arc<Mutex<AppState<C>>>,
+    self_device_id: String,
+    tx: UnboundedSender<Message>,
+) where
+    C: Ciphersuite + Send + Sync + 'static,
+{
+    let advance = {
+        let guard = state.lock().await;
+        let need = guard
+            .session
+            .as_ref()
+            .map(|s| (s.total as usize).saturating_sub(1))
+            .unwrap_or(0);
+        guard.reshare_round1_secret.is_some()
+            && need > 0
+            && guard.reshare_round1_packages.len() >= need
     };
     if advance {
-        let self_id = state.lock().await.device_id.clone();
-        handle_trigger_reshare_round2(state, self_id).await;
+        handle_trigger_reshare_round2(state, self_device_id, tx).await;
     }
 }
 
-/// Produce round-2 packages and send each retained peer its own.
-pub async fn handle_trigger_reshare_round2<C>(state: Arc<Mutex<AppState<C>>>, self_device_id: String)
-where
+/// Produce round-2 packages and send each retained peer its own, then try to
+/// finalize (peers' round-2 may already be buffered).
+pub async fn handle_trigger_reshare_round2<C>(
+    state: Arc<Mutex<AppState<C>>>,
+    self_device_id: String,
+    tx: UnboundedSender<Message>,
+) where
     C: Ciphersuite + Send + Sync + 'static,
 {
     let (participants, original, per_recipient) = {
@@ -316,9 +354,10 @@ where
             }
         }
     }
+    maybe_finalize_reshare(state, tx).await;
 }
 
-/// Ingest a peer's round-2 package; when all are in, finalize + emit.
+/// Ingest a peer's round-2 package, then try to finalize.
 pub async fn process_reshare_round2<C>(
     state: Arc<Mutex<AppState<C>>>,
     from_device_id: String,
@@ -327,12 +366,11 @@ pub async fn process_reshare_round2<C>(
 ) where
     C: Ciphersuite + Send + Sync + 'static,
 {
-    let ready = {
+    {
         let mut guard = state.lock().await;
-        let session = match &guard.session {
-            Some(s) => s.clone(),
-            None => return,
-        };
+        if guard.session.is_none() {
+            return;
+        }
         let original = guard.reshare_original_participants.clone();
         let sender = match reshare_identifier::<C>(&original, &from_device_id) {
             Some(id) => id,
@@ -349,72 +387,94 @@ pub async fn process_reshare_round2<C>(
             }
         };
         add_reshare_round2(&mut guard, sender, pkg);
-        let need = (session.total as usize).saturating_sub(1);
-        guard.reshare_round2_packages.len() >= need && need > 0
+    }
+    maybe_finalize_reshare(state, tx).await;
+}
+
+/// Finalize iff (a) our OWN round-2 secret exists AND (b) all peers' round-2
+/// packages are in — the round-2 analogue of [`maybe_advance_to_reshare_round2`]
+/// (a peer's round-2 can arrive before our own round-2 ran). Swaps the refreshed
+/// share into AppState (group key asserted unchanged), persists it atomically
+/// over the existing wallet, and emits `ReshareComplete`.
+async fn maybe_finalize_reshare<C>(state: Arc<Mutex<AppState<C>>>, tx: UnboundedSender<Message>)
+where
+    C: Ciphersuite + Send + Sync + 'static,
+{
+    let ready = {
+        let guard = state.lock().await;
+        let need = guard
+            .session
+            .as_ref()
+            .map(|s| (s.total as usize).saturating_sub(1))
+            .unwrap_or(0);
+        guard.reshare_round2_secret.is_some()
+            && need > 0
+            && guard.reshare_round2_packages.len() >= need
     };
-    if ready {
-        // Finalize under lock (swaps the in-memory share + asserts the group
-        // key), capturing what we need to persist; then do the keystore IO.
-        let finalized = {
-            let mut guard = state.lock().await;
-            match finalize_reshare(&mut guard) {
-                Ok((new_key, new_pub)) => {
-                    let group_hex = new_pub
-                        .verifying_key()
-                        .serialize()
-                        .map(|b| hex::encode(b))
-                        .unwrap_or_default();
-                    Some((
-                        new_key,
-                        new_pub,
-                        group_hex,
-                        guard.reshare_wallet_id.clone().unwrap_or_default(),
-                        guard.reshare_password.clone(),
-                        guard.reshare_keystore_path.clone(),
-                        guard.device_id.clone(),
-                        guard.session.clone(),
-                    ))
-                }
-                Err(e) => {
-                    error!("reshare finalize: {e}");
-                    None
-                }
+    if !ready {
+        return;
+    }
+    // Finalize under lock (swaps the in-memory share + asserts the group key),
+    // capturing what we need to persist; then do the keystore IO.
+    let finalized = {
+        let mut guard = state.lock().await;
+        match finalize_reshare(&mut guard) {
+            Ok((new_key, new_pub)) => {
+                let group_hex = new_pub
+                    .verifying_key()
+                    .serialize()
+                    .map(|b| hex::encode(b))
+                    .unwrap_or_default();
+                Some((
+                    new_key,
+                    new_pub,
+                    group_hex,
+                    guard.reshare_wallet_id.clone().unwrap_or_default(),
+                    guard.reshare_password.clone(),
+                    guard.reshare_keystore_path.clone(),
+                    guard.device_id.clone(),
+                    guard.session.clone(),
+                ))
             }
-        };
-        if let Some((new_key, new_pub, group_hex, wallet_id, password, path, device_id, session)) =
-            finalized
-        {
-            // Persist the refreshed share atomically over the existing wallet
-            // (same id/curve/group-key/address). Best-effort: a failure here
-            // leaves the in-memory new share usable this session and is logged.
-            if let (Some(password), Some(path), Some(session)) = (password, path, &session) {
-                match crate::elm::command::encode_keystore_blob(&new_key, &new_pub) {
-                    Ok(blob) => match crate::keystore::Keystore::new(&path, &device_id) {
-                        Ok(mut ks) => {
-                            let idx =
-                                ks.get_wallet(&wallet_id).map(|w| w.participant_index).unwrap_or(1);
-                            if let Err(e) = ks.update_wallet_share(
-                                &wallet_id,
-                                &blob,
-                                &password,
-                                session.threshold,
-                                session.total,
-                                session.participants.clone(),
-                                idx,
-                            ) {
-                                error!("reshare persist: update_wallet_share: {e}");
-                            } else {
-                                info!("💾 refreshed share persisted for {}", wallet_id);
-                            }
-                        }
-                        Err(e) => error!("reshare persist: keystore open: {e}"),
-                    },
-                    Err(e) => error!("reshare persist: encode blob: {e}"),
-                }
+            Err(e) => {
+                error!("reshare finalize: {e}");
+                None
             }
-            info!("✅ reshare complete; group key preserved = {}", group_hex);
-            let _ = tx.send(Message::ReshareComplete { wallet_id, group_public_key: group_hex });
         }
+    };
+    if let Some((new_key, new_pub, group_hex, wallet_id, password, path, device_id, session)) =
+        finalized
+    {
+        // Persist the refreshed share atomically over the existing wallet
+        // (same id/curve/group-key/address). Best-effort: a failure here
+        // leaves the in-memory new share usable this session and is logged.
+        if let (Some(password), Some(path), Some(session)) = (password, path, &session) {
+            match crate::elm::command::encode_keystore_blob(&new_key, &new_pub) {
+                Ok(blob) => match crate::keystore::Keystore::new(&path, &device_id) {
+                    Ok(mut ks) => {
+                        let idx =
+                            ks.get_wallet(&wallet_id).map(|w| w.participant_index).unwrap_or(1);
+                        if let Err(e) = ks.update_wallet_share(
+                            &wallet_id,
+                            &blob,
+                            &password,
+                            session.threshold,
+                            session.total,
+                            session.participants.clone(),
+                            idx,
+                        ) {
+                            error!("reshare persist: update_wallet_share: {e}");
+                        } else {
+                            info!("💾 refreshed share persisted for {}", wallet_id);
+                        }
+                    }
+                    Err(e) => error!("reshare persist: keystore open: {e}"),
+                },
+                Err(e) => error!("reshare persist: encode blob: {e}"),
+            }
+        }
+        info!("✅ reshare complete; group key preserved = {}", group_hex);
+        let _ = tx.send(Message::ReshareComplete { wallet_id, group_public_key: group_hex });
     }
 }
 


### PR DESCRIPTION
Completes **#56** (the reshare 4c remainder of #45): networked share refresh/resharing as a first-class **announce/join** ceremony across separate processes, plus an operator-facing CLI and a cross-process L3 test.

Same-set reshare over a pre-existing mesh already worked (#61/#62, phase 4b). This makes reshare work the way a real deployment runs it — each device its own process, loading its old share from disk, forming a fresh WebRTC mesh, and refreshing.

## How it works
Mesh formation is driven by `app_state.session` + signal-server `participant_update` frames (`model.active_session` is display-only), and every node converges on `StartFrostProtocol` at mesh-ready. So reshare **reuses that entire machinery** and forks at exactly one point, on `app_state.reshare_in_progress`:

- **Discovery**: `parse_session_info` recognizes `"reshare"` announces as `SessionType::Reshare`.
- **Trigger fork**: `StartFrostProtocol` runs reshare round 1 instead of DKG round 1 when a reshare is pending.
- **Initiator** (`Command::StartReshare`): loads the OLD share + ORIGINAL participant set from the keystore, then announces a reshare session.
- **Joiner** (`Command::JoinReshare`, wired from the SubmitPassword `Reshare` arm — previously a no-op): loads the OLD share, joins so the mesh grows.
- The ORIGINAL participant set is seeded from persisted metadata (design §3), never the retained/mesh set — so removing a middle device can't renumber survivors.

## CLI / serve
- `mpc-wallet-cli reshare --wallet-id W ...` initiates; retained signers approve with the existing `session join` (or `serve --auto-approve`, now symmetric with signing).
- New `reshare` command + `reshare_complete` event in the JSONL protocol (+ schema).

## Robustness fixes (surfaced by the L3 test)
- **Round-ordering races**: a peer's round-N package can arrive before this node generated its own round-N secret. `maybe_advance_to_reshare_round2` / `maybe_finalize_reshare` gate the transition on our own secret existing (DKG sidesteps this because its round-1 map includes self; reshare's holds peers only).
- **Stale-session mesh**: `StartFrostProtocol` now ignores a mesh-ready when no DKG/reshare is actually pending, so a completed session still listed on a reused signal server can't pin `dkg_state` and block a later reshare.
- **simulate**: tears the DKG cluster down before spawning the reshare cluster so accumulated ICE agents don't exhaust loopback sockets across the sequential e2e suite.

## Tests (all green)
- New L3 `reshare_then_sign_across_serve_processes`: DKG → kill both processes → fresh `serve` processes on the same keystores → reshare → group key (address) preserved → sign with refreshed shares → verify.
- `reshare_then_sign_2_of_3` (in-process e2e) reworked to the fresh-runner announce/join path.
- Full CI set: tui-node lib 89, e2e_dkg 4, l3_serve_process 6, conformance 9, wire_trace 2, cli unit 31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)