### PR TITLE
fix(ext): connect signal WS after room is configured + advance L3c interop (#33)

### DIFF
--- a/apps/browser-extension/src/components/Settings.svelte
+++ b/apps/browser-extension/src/components/Settings.svelte
@@ -38,9 +38,21 @@
             roomStatus = "✗ Need ≥16 chars of [A-Za-z0-9_-] (use Generate).";
             return;
         }
-        roomStatus = (await setRoom(r))
-            ? "✓ Saved. Reconnect to apply."
-            : "✗ Save failed.";
+        if (!(await setRoom(r))) {
+            roomStatus = "✗ Save failed.";
+            return;
+        }
+        // Apply immediately: the startup WS connect is roomless (it ran before a
+        // room existed) and the multi-tenant server rejects it, so without a
+        // reconnect the saved room never takes effect. Ask the background to
+        // re-resolve the URL and reconnect.
+        roomStatus = "✓ Saved — reconnecting…";
+        try {
+            await chrome.runtime.sendMessage({ type: "reconnectSignal" });
+            roomStatus = "✓ Saved & reconnecting.";
+        } catch (e) {
+            roomStatus = "✓ Saved. Reload the extension to apply.";
+        }
     }
     const dispatch = createEventDispatcher<{
         backToWallet: { chain: string; curve: string };

--- a/apps/browser-extension/src/entrypoints/background/messageHandlers.ts
+++ b/apps/browser-extension/src/entrypoints/background/messageHandlers.ts
@@ -127,6 +127,11 @@ export class PopupMessageHandler {
                     await this.handleListDevicesRequest(sendResponse);
                     break;
 
+                case "reconnectSignal":
+                    console.log("🔌 [PopupMessageHandler] RECONNECT_SIGNAL: reconnecting to apply saved room/server");
+                    await this.handleReconnectSignal(sendResponse);
+                    break;
+
                 case MESSAGE_TYPES.RELAY:
 //                     console.log("🔄 [PopupMessageHandler] RELAY: Forwarding message via WebSocket");
                     await this.handleRelayRequest(message, sendResponse);
@@ -479,6 +484,24 @@ export class PopupMessageHandler {
         } else {
             console.warn("[PopupMessageHandler] WebSocket not connected, cannot list devices");
             sendResponse({ success: false, error: result.error });
+        }
+    }
+
+    /**
+     * Reconnect the signal-server WebSocket using the freshly saved room /
+     * server override. The startup connect is roomless (it runs before any room
+     * is configured) and the multi-tenant server rejects it; this re-resolves
+     * the URL so the new room takes effect without reloading the extension.
+     */
+    private async handleReconnectSignal(sendResponse: (response: any) => void): Promise<void> {
+        try {
+            await this.webSocketManager.reconnect();
+            sendResponse({ success: true });
+        } catch (error) {
+            sendResponse({
+                success: false,
+                error: error instanceof Error ? error.message : String(error),
+            });
         }
     }
 

--- a/apps/browser-extension/src/entrypoints/background/webSocketManager.ts
+++ b/apps/browser-extension/src/entrypoints/background/webSocketManager.ts
@@ -138,6 +138,26 @@ export class WebSocketManager {
     }
 
     /**
+     * Tear down the current connection (if any) and reconnect using a freshly
+     * resolved signal-server URL. This is how a room / signal-server override
+     * saved AFTER startup takes effect: the startup connect runs before any room
+     * is set, so it dials a roomless URL the multi-tenant server rejects (#31).
+     * Re-resolving here picks up the saved `?room=…` so the socket is accepted.
+     * Wired to the popup's "Save room" action (Settings) and used by the L3c
+     * interop harness so the extension joins the co-signers' room (#33).
+     */
+    async reconnect(): Promise<void> {
+        console.log("[WebSocketManager] reconnect requested — re-resolving URL with saved room");
+        try {
+            this.wsClient?.disconnect();
+        } catch (e) {
+            console.warn("[WebSocketManager] reconnect: error closing existing client:", e);
+        }
+        const url = await getSignalServerUrl();
+        await this.initialize(url, this.appState.deviceId || "mpc-2");
+    }
+
+    /**
      * Set up WebSocket event handlers
      */
     private setupEventHandlers(): void {

--- a/apps/browser-extension/src/entrypoints/background/webSocketManager.ts
+++ b/apps/browser-extension/src/entrypoints/background/webSocketManager.ts
@@ -163,10 +163,19 @@ export class WebSocketManager {
     private setupEventHandlers(): void {
         if (!this.wsClient) return;
 
+        // Capture the client these handlers belong to. After a reconnect() the
+        // superseded client's close/error fires asynchronously (the close
+        // handshake outlives `disconnect()`), which would clobber the NEW
+        // connection's wsConnected=true back to false. Ignore any event whose
+        // client is no longer the active one. (#33)
+        const client = this.wsClient;
+        const isStale = () => this.wsClient !== client;
+
         console.log("[WebSocketManager] Setting up WebSocket event handlers");
 
         // Handle connection open
         this.wsClient.onOpen(() => {
+            if (isStale()) return;
             console.log("[WebSocketManager] WebSocket onOpen event triggered - connection established");
 
             // Use StateManager to update and persist WebSocket status
@@ -261,6 +270,10 @@ export class WebSocketManager {
 
         // Handle connection close
         this.wsClient.onClose((event) => {
+            if (isStale()) {
+                console.log("[WebSocketManager] Ignoring onClose from a superseded client (post-reconnect)");
+                return;
+            }
             console.log("[WebSocketManager] WebSocket onClose event triggered, event:", event);
 
             // Use StateManager to update and persist WebSocket status
@@ -284,6 +297,10 @@ export class WebSocketManager {
 
         // Handle connection errors
         this.wsClient.onError((error) => {
+            if (isStale()) {
+                console.log("[WebSocketManager] Ignoring onError from a superseded client (post-reconnect)");
+                return;
+            }
             console.error("[WebSocketManager] WebSocket onError event triggered, error:", error);
 
             // Use StateManager to update and persist WebSocket status
@@ -310,6 +327,7 @@ export class WebSocketManager {
 
         // Set up the message handler
         this.wsClient.onMessage((message: any) => {
+            if (isStale()) return;
             this.handleWebSocketMessage(message);
         });
     }

--- a/apps/browser-extension/src/entrypoints/background/webSocketManager.ts
+++ b/apps/browser-extension/src/entrypoints/background/webSocketManager.ts
@@ -178,11 +178,15 @@ export class WebSocketManager {
             if (isStale()) return;
             console.log("[WebSocketManager] WebSocket onOpen event triggered - connection established");
 
-            // Use StateManager to update and persist WebSocket status
+            // Use StateManager to update and persist WebSocket status. Also set
+            // `this.appState.wsConnected` directly: the `initialState` broadcast
+            // below spreads `this.appState`, and `updateWebSocketStatus` does NOT
+            // write through to it — so without this the full-state message would
+            // carry a stale `wsConnected:false` that arrives AFTER the
+            // `wsStatus:true` above and clobbers the popup back to disconnected.
+            this.appState.wsConnected = true;
             if (this.stateManager) {
                 this.stateManager.updateWebSocketStatus(true);
-            } else {
-                this.appState.wsConnected = true;
             }
 
             // Broadcast connection status immediately to any connected popups
@@ -276,11 +280,11 @@ export class WebSocketManager {
             }
             console.log("[WebSocketManager] WebSocket onClose event triggered, event:", event);
 
-            // Use StateManager to update and persist WebSocket status
+            // Keep `this.appState` in sync (the initialState broadcast below
+            // spreads it; updateWebSocketStatus doesn't write through).
+            this.appState.wsConnected = false;
             if (this.stateManager) {
                 this.stateManager.updateWebSocketStatus(false, `Connection closed: ${event.code} ${event.reason}`);
-            } else {
-                this.appState.wsConnected = false;
             }
 
             // Broadcast disconnection status
@@ -303,11 +307,11 @@ export class WebSocketManager {
             }
             console.error("[WebSocketManager] WebSocket onError event triggered, error:", error);
 
-            // Use StateManager to update and persist WebSocket status
+            // Keep `this.appState` in sync (the initialState broadcast below
+            // spreads it; updateWebSocketStatus doesn't write through).
+            this.appState.wsConnected = false;
             if (this.stateManager) {
                 this.stateManager.updateWebSocketStatus(false, error.toString());
-            } else {
-                this.appState.wsConnected = false;
             }
 
             // Broadcast error and disconnection status

--- a/apps/browser-extension/tests/interop/extension-actions.ts
+++ b/apps/browser-extension/tests/interop/extension-actions.ts
@@ -40,26 +40,61 @@ export async function setRoom(page: Page, room: string): Promise<void> {
   await page.getByTestId("room-status").filter({ hasText: /saved/i }).waitFor({ timeout: 10_000 });
 }
 
-// --- FIRST-RUN: create wallet (DKG initiator) -------------------------------
+// --- create wallet (DKG initiator) ------------------------------------------
+
+/** Leave the Settings view (its "Done" button) so the wallet view is showing. */
+export async function closeSettings(page: Page): Promise<void> {
+  const done = page.getByRole("button", { name: /^done$/i });
+  if (await done.count()) {
+    await done.first().click();
+  }
+}
 
 /**
  * Create a threshold wallet — the extension becomes the DKG initiator.
- * Selectors here are the first-run starting point; confirm on a headed run.
+ *
+ * Selectors verified against CreateWalletForm.svelte: stable ids `#cw-total`,
+ * `#cw-threshold`, `#cw-curve`; both the main-view trigger and the form's submit
+ * are labelled "Create wallet", but the main view unmounts when the form opens
+ * (App.svelte `{#if showSettings}{:else if showCreateWallet}{:else}…`), so the
+ * post-open lookup resolves to the submit. The DKG-creation form has no password
+ * field (the keystore password is collected later), so `opts.password` is unused
+ * here.
  */
 export async function createWallet(
   page: Page,
   opts: { threshold: number; total: number; password: string; curve: string },
 ): Promise<void> {
-  await page.getByRole("button", { name: /create wallet/i }).first().click();
-  // CreateWalletForm overlay — threshold/total/curve inputs + submit.
-  // NEEDS-VERIFY: field names below are placeholders for the first headed run.
-  const thr = page.getByLabel(/threshold/i);
-  if (await thr.count()) await thr.fill(String(opts.threshold));
-  const tot = page.getByLabel(/total|participants/i);
-  if (await tot.count()) await tot.fill(String(opts.total));
-  const pw = page.getByLabel(/password/i);
-  if (await pw.count()) await pw.first().fill(opts.password);
-  await page.getByRole("button", { name: /create|start|generate/i }).last().click();
+  // `setRoom` leaves us on Settings; return to the wallet view.
+  await closeSettings(page);
+
+  // The main-view "Create wallet" button is `disabled` until the background
+  // reports wsConnected (it enables once the post-room reconnect lands). Assert
+  // it becomes enabled so a connection failure is a clear error, not a vague
+  // click timeout.
+  const trigger = page.getByRole("button", { name: /create wallet/i }).first();
+  await trigger.waitFor({ state: "visible", timeout: 20_000 });
+  await page.waitForFunction(
+    () => {
+      const b = Array.from(document.querySelectorAll("button")).find((el) =>
+        /create wallet/i.test(el.textContent ?? ""),
+      );
+      return !!b && !(b as HTMLButtonElement).disabled;
+    },
+    { timeout: 30_000 },
+  );
+  await trigger.click();
+
+  // CreateWalletForm overlay — fill the real inputs (defaults already match a
+  // 2-of-3, but set them explicitly so the test controls the shape).
+  await page.locator("#cw-total").fill(String(opts.total));
+  await page.locator("#cw-threshold").fill(String(opts.threshold));
+  if (opts.curve) {
+    await page.locator("#cw-curve").selectOption(opts.curve).catch(() => {});
+  }
+
+  // Submit (form's button is also "Create wallet"; main view is unmounted now).
+  await page.getByRole("button", { name: /^create wallet$/i }).click();
 }
 
 /**


### PR DESCRIPTION
A real product bug, found while wiring the L3c interop runner: **a fresh extension could never connect to the signal server.** The background connects once at startup — before any room is set — so it dials a roomless URL the multi-tenant server rejects (#31), and nothing reconnects. Settings even said *"Reconnect to apply"* with no way to do so. Because the *Create wallet* button is gated on `wsConnected`, it stayed disabled forever.

### Fixes (background)
1. **`WebSocketManager.reconnect()`** — close the stale client and re-resolve the URL (now with the saved `?room=`), then reconnect. New `reconnectSignal` background message; Settings "Save room" calls it and reports "Saved & reconnecting".
2. **Ignore events from a superseded client** — after reconnect, the old client's close handshake outlives `disconnect()`, so its `onClose` fired *after* the new `onOpen` and clobbered `wsConnected` back to false. `setupEventHandlers` now ignores `onOpen/onClose/onError/onMessage` once its client is no longer active.
3. **Write `wsConnected` through to `appState`** — `onOpen` broadcast `wsStatus{true}` then a full `initialState` spreading `this.appState`, but `updateWebSocketStatus` only updates the StateManager, so the trailing message carried a stale `false` that clobbered the popup. Set `this.appState.wsConnected` in `onOpen/onClose/onError`.

### Harness (#33)
`extension-actions.createWallet` returns to the wallet view (Settings "Done"), waits for the button to **enable** (wsConnected), and uses verified `CreateWalletForm` ids (`#cw-total`/`#cw-threshold`/`#cw-curve`).

### Validation (workflow_dispatch on this branch, run 27093308715)
Each fix was verified against the live trace. End state on a GitHub runner:
- ✅ boundary smoke green
- ✅ extension connects with the room, **Create wallet** enables, DKG announced (`dkg_…`)
- ✅ **both CLI peers discover and join the extension's DKG session ("joining … 2/3")** — the cross-impl boundary is exercised
- ❌ DKG key-gen doesn't complete: the WebRTC mesh needs real UDP/ICE, which GitHub's shared runners don't provide (same limit the Rust e2e steps carry in `ci.yml`). Needs a self-hosted runner — not a code/harness bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)