### PR TITLE
fix(cli): actionable error messages on every one-shot failure (投资人友好)

### DIFF
--- a/apps/cli-node/src/oneshot.rs
+++ b/apps/cli-node/src/oneshot.rs
@@ -3,6 +3,11 @@
 //! the result as JSON, and map it to an exit code. Thin wrappers over the
 //! same runner + bridge that `serve` uses — for humans/scripts that want a
 //! single blocking command instead of the JSONL daemon.
+//!
+//! Error UX: these commands are the surface investors poke at by hand, so every
+//! failure path returns an **actionable** message (what failed + the most likely
+//! cause + the next thing to try) rather than a bare "timed out". See
+//! `connect_help` and the per-command `wait_outcome` hints.
 
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -55,29 +60,89 @@ fn start(opts: &OneShotOpts) -> (UnboundedSender<Message>, UnboundedReceiver<Cli
     (tx, ev_rx)
 }
 
-async fn wait_event<P>(
+/// Actionable message when the signal-server connection never establishes —
+/// the #1 thing a hands-on user trips over (a roomless hosted connection is
+/// silently rejected, so it just "hangs" until this 15s timeout).
+fn connect_help(opts: &OneShotOpts, secs: u64) -> String {
+    let hosted = opts.signal_url.starts_with("wss://");
+    let has_room = opts.signal_url.contains("room=");
+    let mut s = format!(
+        "could not connect to the signal server within {secs}s ({}).",
+        opts.signal_url
+    );
+    if hosted && !has_room {
+        s.push_str(
+            "\n  → No --room set. The hosted server requires a strong room (≥16 chars); a \
+             roomless connection is rejected.\
+             \n    Add the SAME value on every device, e.g.  --room \"$(uuidgen | tr -d -)\".",
+        );
+    } else {
+        s.push_str(
+            "\n  → Check the server is reachable and you're online. For a LAN/offline demo, run a \
+             local server and use  --signal-server ws://<host-ip>:9000  (no room needed).",
+        );
+    }
+    s.push_str(
+        "\n  → To prove the cryptography with no server at all:  \
+         mpc-wallet-cli simulate --nodes 3 --threshold 2 --sign hello",
+    );
+    s
+}
+
+/// Wait for the signal-server connection; on timeout return [`connect_help`].
+/// A server-sent error frame (e.g. weak/missing room) surfaces immediately.
+async fn wait_connected(rx: &mut UnboundedReceiver<CliEvent>, opts: &OneShotOpts) -> anyhow::Result<()> {
+    const SECS: u64 = 15;
+    if opts.signal_url.starts_with("wss://") && !opts.signal_url.contains("room=") {
+        eprintln!(
+            "note: no --room set — the hosted server requires a strong --room (≥16 chars); \
+             if this hangs, that's why."
+        );
+    }
+    let res = tokio::time::timeout(Duration::from_secs(SECS), async {
+        loop {
+            match rx.recv().await {
+                Some(CliEvent::Connection { connected: true }) => return Ok(()),
+                Some(CliEvent::Error { code, message, .. }) => anyhow::bail!("{code}: {message}"),
+                Some(_) => continue,
+                None => anyhow::bail!("the runner stopped before it could connect"),
+            }
+        }
+    })
+    .await;
+    match res {
+        Ok(inner) => inner,
+        Err(_) => Err(anyhow::anyhow!(connect_help(opts, SECS))),
+    }
+}
+
+/// Wait for a terminal outcome. On a runtime error, surface it verbatim; on
+/// timeout, append `hint` (what to check) to a clear "timed out waiting for X".
+async fn wait_outcome<P>(
     rx: &mut UnboundedReceiver<CliEvent>,
     secs: u64,
+    waiting_for: &str,
+    hint: &str,
     pred: P,
 ) -> anyhow::Result<CliEvent>
 where
     P: Fn(&CliEvent) -> bool,
 {
-    tokio::time::timeout(Duration::from_secs(secs), async {
+    let res = tokio::time::timeout(Duration::from_secs(secs), async {
         loop {
             match rx.recv().await {
                 Some(e) if pred(&e) => return Ok(e),
-                // Surface a server/runtime error promptly instead of waiting.
-                Some(CliEvent::Error { code, message, .. }) => {
-                    anyhow::bail!("{code}: {message}")
-                }
+                Some(CliEvent::Error { code, message, .. }) => anyhow::bail!("{code}: {message}"),
                 Some(_) => continue,
-                None => anyhow::bail!("runner stopped before the expected event"),
+                None => anyhow::bail!("the runner stopped before {waiting_for}"),
             }
         }
     })
-    .await
-    .map_err(|_| anyhow::anyhow!("timed out after {secs}s"))?
+    .await;
+    match res {
+        Ok(inner) => inner,
+        Err(_) => Err(anyhow::anyhow!("timed out after {secs}s waiting for {waiting_for}.{hint}")),
+    }
 }
 
 fn print(ev: &CliEvent) {
@@ -91,7 +156,14 @@ fn print(ev: &CliEvent) {
 pub async fn wallet_list(opts: OneShotOpts) -> anyhow::Result<bool> {
     let (tx, mut rx) = start(&opts);
     tx.send(Message::ListWallets)?;
-    let ev = wait_event(&mut rx, 5, |e| matches!(e, CliEvent::Wallets { .. })).await?;
+    let ev = wait_outcome(
+        &mut rx,
+        5,
+        "the wallet list",
+        &format!("\n  → Check the --keystore path is readable ({}).", opts.keystore_path),
+        |e| matches!(e, CliEvent::Wallets { .. }),
+    )
+    .await?;
     print(&ev);
     Ok(true)
 }
@@ -104,12 +176,28 @@ pub async fn wallet_create(
     total: u16,
     password: String,
 ) -> anyhow::Result<bool> {
+    if total < 2 {
+        anyhow::bail!(
+            "--total must be ≥ 2 (got {total}). A shared wallet needs at least two devices; \
+             the classic demo is --total 3 --threshold 2 (2-of-3)."
+        );
+    }
+    if threshold < 1 || threshold > total {
+        anyhow::bail!(
+            "--threshold must be between 1 and --total ({total}); got {threshold}. \
+             Tip: 2-of-3 = --threshold 2 --total 3."
+        );
+    }
     let (tx, mut rx) = start(&opts);
     tx.send(Message::TriggerReconnect)?;
-    wait_event(&mut rx, 15, |e| {
-        matches!(e, CliEvent::Connection { connected: true })
-    })
-    .await?;
+    wait_connected(&mut rx, &opts).await?;
+    eprintln!(
+        "note: announcing a {threshold}-of-{total} DKG as device '{}'. Waiting up to {}s for the \
+         other {} participant(s) to join (same --room, a UNIQUE --device-id each)…",
+        opts.device_id,
+        opts.timeout_secs,
+        total - 1
+    );
     tx.send(Message::HeadlessCreateWallet {
         config: WalletConfig {
             name: name.clone(),
@@ -120,9 +208,14 @@ pub async fn wallet_create(
         password,
         label: name,
     })?;
-    let ev = wait_event(&mut rx, opts.timeout_secs, |e| {
-        matches!(e, CliEvent::DkgComplete { .. })
-    })
+    let ev = wait_outcome(
+        &mut rx,
+        opts.timeout_secs,
+        "the DKG to complete",
+        "\n  → DKG needs ALL participants online together. Did the other devices run \
+         `mpc-wallet-cli session join` with the SAME --room and a unique --device-id each?",
+        |e| matches!(e, CliEvent::DkgComplete { .. }),
+    )
     .await?;
     print(&ev);
     Ok(true)
@@ -136,10 +229,7 @@ pub async fn session_join(
 ) -> anyhow::Result<bool> {
     let (tx, mut rx) = start(&opts);
     tx.send(Message::TriggerReconnect)?;
-    wait_event(&mut rx, 15, |e| {
-        matches!(e, CliEvent::Connection { connected: true })
-    })
-    .await?;
+    wait_connected(&mut rx, &opts).await?;
     // Give the server a moment to replay the session, then join.
     tokio::time::sleep(Duration::from_secs(3)).await;
     tx.send(Message::HeadlessJoinSession {
@@ -147,14 +237,21 @@ pub async fn session_join(
         password,
         label: String::new(),
     })?;
-    let ev = wait_event(&mut rx, opts.timeout_secs, |e| {
-        matches!(
-            e,
-            CliEvent::DkgComplete { .. }
-                | CliEvent::SignatureComplete { .. }
-                | CliEvent::ReshareComplete { .. }
-        )
-    })
+    let ev = wait_outcome(
+        &mut rx,
+        opts.timeout_secs,
+        "the session to complete",
+        "\n  → Is the session id correct and the creator still online in the SAME --room? \
+         Everyone must share --room and --signal-server; the password must match this wallet.",
+        |e| {
+            matches!(
+                e,
+                CliEvent::DkgComplete { .. }
+                    | CliEvent::SignatureComplete { .. }
+                    | CliEvent::ReshareComplete { .. }
+            )
+        },
+    )
     .await?;
     print(&ev);
     Ok(true)
@@ -171,18 +268,21 @@ pub async fn reshare(
 ) -> anyhow::Result<bool> {
     let (tx, mut rx) = start(&opts);
     tx.send(Message::TriggerReconnect)?;
-    wait_event(&mut rx, 15, |e| {
-        matches!(e, CliEvent::Connection { connected: true })
-    })
-    .await?;
+    wait_connected(&mut rx, &opts).await?;
     tx.send(Message::HeadlessReshare {
         wallet_id,
         password,
         keystore_path: opts.keystore_path.clone(),
     })?;
-    let ev = wait_event(&mut rx, opts.timeout_secs, |e| {
-        matches!(e, CliEvent::ReshareComplete { .. })
-    })
+    let ev = wait_outcome(
+        &mut rx,
+        opts.timeout_secs,
+        "the reshare to complete",
+        "\n  → Reshare needs the retained signers to join the announced session in the SAME \
+         --room (via `session join`, or `serve --auto-approve`). Check --wallet-id exists \
+         (`wallet list`) and the password matches.",
+        |e| matches!(e, CliEvent::ReshareComplete { .. }),
+    )
     .await?;
     print(&ev);
     Ok(true)
@@ -198,19 +298,22 @@ pub async fn sign(
 ) -> anyhow::Result<bool> {
     let (tx, mut rx) = start(&opts);
     tx.send(Message::TriggerReconnect)?;
-    wait_event(&mut rx, 15, |e| {
-        matches!(e, CliEvent::Connection { connected: true })
-    })
-    .await?;
+    wait_connected(&mut rx, &opts).await?;
     tx.send(Message::HeadlessSign {
         wallet_id,
         message,
         encoding,
         password,
     })?;
-    let ev = wait_event(&mut rx, opts.timeout_secs, |e| {
-        matches!(e, CliEvent::SignatureComplete { .. })
-    })
+    let ev = wait_outcome(
+        &mut rx,
+        opts.timeout_secs,
+        "the signature",
+        "\n  → Signing needs a quorum to approve. Did a co-signer run `session join` (or \
+         `serve --auto-approve`) on the announced session in the SAME --room? Check --wallet-id \
+         exists (`wallet list`) and the password matches.",
+        |e| matches!(e, CliEvent::SignatureComplete { .. }),
+    )
     .await?;
     print(&ev);
     Ok(true)


### PR DESCRIPTION
投资人会乱实验,工具得"乱按也看得懂"。把 CLI 一次性命令的每个失败路径都改成:**出了什么错 + 最可能的原因 + 下一步怎么做**。

Triggered by the report: `mpc-wallet-cli wallet create --password 1` → bare `error: timed out after 15s` (the real cause was the missing `--room`).

**Before**
```
error: timed out after 15s
```
**After**
```
note: no --room set — the hosted server requires a strong --room (≥16 chars); if this hangs, that's why.
error: could not connect to the signal server within 15s (wss://panda.qzz.io).
  → No --room set. The hosted server requires a strong room (≥16 chars); a roomless connection is rejected.
    Add the SAME value on every device, e.g.  --room "$(uuidgen | tr -d -)".
  → To prove the cryptography with no server at all:  mpc-wallet-cli simulate --nodes 3 --threshold 2 --sign hello
```

What changed (`apps/cli-node/src/oneshot.rs`):
- **Connection failures** — the #1 footgun. A roomless hosted connection is silently rejected → it hangs to the 15s timeout. Now a proactive note up front + a `connect_help` message explaining the room requirement (or network / LAN-server fallback), and pointing at `simulate` for a no-server proof.
- **Operation timeouts** (DKG / sign / reshare / join) — each now says what it waited for and who still needs to join (same `--room`, unique `--device-id`, matching password, correct `--wallet-id`).
- **Arg validation** — `wallet create` rejects bad `--threshold`/`--total` instantly with a 2-of-3 tip (no 15s wait).
- Server-sent error frames still surface verbatim and immediately.
- Refactor: duplicated connect/await blocks → `wait_connected` + `wait_outcome`.

Verified by reproducing the original command + bad-args case; cli unit tests green (31).

🤖 Generated with [Claude Code](https://claude.com/claude-code)