### PR TITLE
fix(serve,tui): actionable error messages (投资人乱按也看得懂)

### DIFF
--- a/apps/cli-node/src/serve.rs
+++ b/apps/cli-node/src/serve.rs
@@ -185,7 +185,11 @@ pub async fn serve(opts: ServeOpts) -> anyhow::Result<()> {
                 let _ = out_tx.send(CliEvent::Error {
                     correlates: None,
                     code: "bad_request".into(),
-                    message: e.to_string(),
+                    message: format!(
+                        "invalid JSONL command: {e}. Expected one JSON object per line, e.g. \
+                         {{\"cmd\":\"create_wallet\",\"threshold\":2,\"total\":3,\"password\":\"…\"}}. \
+                         Run `mpc-wallet-cli schema` for the full command list."
+                    ),
                 });
                 continue;
             }
@@ -199,6 +203,22 @@ pub async fn serve(opts: ServeOpts) -> anyhow::Result<()> {
 
         match req.command {
             CliCommand::Connect => {
+                // A roomless connection to the hosted (wss://) server is rejected
+                // by the multi-tenant signal server, so the connection will never
+                // come up — tell the operator why, in-band, instead of letting
+                // every later command silently hang.
+                if opts.signal_url.starts_with("wss://") && !opts.signal_url.contains("room=") {
+                    let _ = out_tx.send(CliEvent::Error {
+                        correlates: id,
+                        code: "room_required".into(),
+                        message: format!(
+                            "no room set for the hosted server ({}). It requires a strong room \
+                             (≥16 chars) — a roomless connection is rejected. Restart `serve` with \
+                             --room <id> (the SAME value on every node).",
+                            opts.signal_url
+                        ),
+                    });
+                }
                 let _ = runner_tx.send(Message::TriggerReconnect);
                 ack(id);
             }

--- a/apps/tui-node/src/elm/command.rs
+++ b/apps/tui-node/src/elm/command.rs
@@ -651,7 +651,7 @@ impl Command {
                             _ => {
                                 warn!("StartDKG: primary WebSocket not up — can't announce");
                                 let _ = tx_clone.send(Message::DKGFailed {
-                                    error: "Signal server not connected. Wait for reconnect and try again.".to_string(),
+                                    error: crate::elm::error_help::not_connected(),
                                 });
                                 drop(state);
                                 let mut s = app_state.lock().await;
@@ -1036,8 +1036,7 @@ impl Command {
                         None => {
                             warn!("StartReshare: primary WebSocket not up — can't announce");
                             let _ = tx.send(Message::Error {
-                                message: "Signal server not connected. Wait for reconnect."
-                                    .to_string(),
+                                message: crate::elm::error_help::not_connected(),
                             });
                             let mut s = app_state.lock().await;
                             crate::protocal::reshare::clear_reshare_state(&mut s);
@@ -1130,8 +1129,7 @@ impl Command {
                         None => {
                             warn!("JoinReshare: primary WebSocket not up — can't join");
                             let _ = tx.send(Message::Error {
-                                message: "Signal server not connected. Wait for reconnect."
-                                    .to_string(),
+                                message: crate::elm::error_help::not_connected(),
                             });
                             let mut s = app_state.lock().await;
                             crate::protocal::reshare::clear_reshare_state(&mut s);
@@ -1270,7 +1268,7 @@ impl Command {
                         _ => {
                             warn!("JoinDKG: primary WebSocket not up — can't join");
                             let _ = tx_clone.send(Message::DKGFailed {
-                                error: "Signal server not connected. Wait for reconnect.".to_string(),
+                                error: crate::elm::error_help::not_connected(),
                             });
                             return Ok(());
                         }

--- a/apps/tui-node/src/elm/error_help.rs
+++ b/apps/tui-node/src/elm/error_help.rs
@@ -1,0 +1,124 @@
+//! User-facing error guidance.
+//!
+//! Turns raw / internal error strings into messages an investor fumbling the
+//! live demo can act on: *what failed + the most likely cause + the next thing
+//! to try*. These wrap the upstream error at the display chokepoints (the
+//! `DKGFailed` / `SigningFailed` / `WalletUnlockFailed` / connection handlers)
+//! so we add guidance in one place instead of rewriting every error site.
+//!
+//! Classification is intentionally keyword-based and conservative: when we
+//! recognise a cause we say something specific; otherwise we keep the raw error
+//! and append general "what to check" guidance. We never hide the original text.
+
+/// Guidance appended to a DKG (wallet-creation) failure.
+pub fn dkg(error: &str) -> String {
+    let e = error.to_lowercase();
+    let hint = if e.contains("timeout") || e.contains("timed out") || e.contains("waiting") {
+        "\n→ DKG needs ALL participants online together. Check every device used the SAME \
+         signal server + room, a UNIQUE device id each, and that the network is up."
+    } else if e.contains("connect") || e.contains("websocket") || e.contains("signal") || e.contains("offline") {
+        "\n→ Couldn't reach the signal server. Check your network / the signal-server URL, or \
+         use a LAN server (ws://<host-ip>:9000)."
+    } else if e.contains("room") {
+        "\n→ The hosted server needs a strong room (≥16 chars), the SAME on every device."
+    } else if e.contains("duplicate") || e.contains("already registered") {
+        "\n→ Two devices share a device id. Give each participant a UNIQUE device id and retry."
+    } else {
+        "\n→ Make sure all participants are online in the same room with unique device ids. \
+         If it persists, rebuild to the latest and retry."
+    };
+    format!("DKG didn't finish: {error}{hint}")
+}
+
+/// Guidance appended to a threshold-signing failure.
+pub fn signing(error: &str) -> String {
+    let e = error.to_lowercase();
+    let hint = if e.contains("timeout") || e.contains("timed out") || e.contains("waiting") {
+        "\n→ Signing needs a quorum (the threshold) to approve. Make sure enough co-signers are \
+         online in the same room and approved the request."
+    } else if e.contains("password") || e.contains("decrypt") || e.contains("unlock") {
+        "\n→ Wrong password for this wallet on this device. Re-enter the password you set here."
+    } else if e.contains("connect") || e.contains("signal") || e.contains("offline") {
+        "\n→ Couldn't reach the signal server / co-signers. Check the network and that everyone \
+         is in the same room."
+    } else {
+        "\n→ Check that at least the threshold number of co-signers are online in the same room \
+         and approved the request."
+    };
+    format!("Signing didn't complete: {error}{hint}")
+}
+
+/// Classify an unlock failure into a `(title, message)` an end user can act on.
+pub fn unlock(error: &str) -> (String, String) {
+    let e = error.to_lowercase();
+    if e.contains("invalid password")
+        || e.contains("wrong password")
+        || e.contains("decrypt")
+        || e.contains("aead")
+        || e.contains("mac")
+    {
+        return (
+            "Wrong password".to_string(),
+            "That password didn't unlock this wallet. Enter the password you set for THIS wallet \
+             on THIS device — each device has its own password."
+                .to_string(),
+        );
+    }
+    if e.contains("not found") || e.contains("no wallet") || e.contains("missing") {
+        return (
+            "Wallet not found".to_string(),
+            "No wallet with that id was found on this device. Check you're using the right device \
+             id and keystore, and the wallet id from your wallet list. A wallet's shares live only \
+             on the devices that ran its DKG."
+                .to_string(),
+        );
+    }
+    (
+        "Unlock failed".to_string(),
+        format!(
+            "Couldn't open the wallet: {error}\n→ Check the password is correct and the keystore \
+             file isn't corrupted."
+        ),
+    )
+}
+
+/// Guidance shown when the signal-server connection isn't up. We don't always
+/// have the URL at the call site, so this covers both common causes.
+pub fn not_connected() -> String {
+    "Not connected to the signal server.\n→ If you're using the hosted server, it requires a \
+     strong room (≥16 chars), the SAME on every device — restart with --room <id>.\n→ Otherwise \
+     check your network / the --signal-server URL, or run a local LAN server (ws://<host-ip>:9000)."
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unlock_detects_wrong_password() {
+        let (title, _) = unlock("UnlockWallet: load_wallet_file failed: Invalid password");
+        assert_eq!(title, "Wrong password");
+    }
+
+    #[test]
+    fn unlock_detects_missing_wallet() {
+        let (title, _) = unlock("wallet 'abc' not found in keystore");
+        assert_eq!(title, "Wallet not found");
+    }
+
+    #[test]
+    fn unlock_falls_back_but_keeps_raw() {
+        let (title, msg) = unlock("some novel keystore failure");
+        assert_eq!(title, "Unlock failed");
+        assert!(msg.contains("some novel keystore failure"));
+    }
+
+    #[test]
+    fn dkg_and_signing_keep_raw_and_add_hint() {
+        let d = dkg("timed out after 90s");
+        assert!(d.contains("timed out after 90s") && d.contains("→"));
+        let s = signing("peer offline");
+        assert!(s.contains("peer offline") && s.contains("→"));
+    }
+}

--- a/apps/tui-node/src/elm/mod.rs
+++ b/apps/tui-node/src/elm/mod.rs
@@ -8,6 +8,7 @@ pub mod model;
 pub mod message;
 pub mod update;
 pub mod command;
+pub mod error_help;
 pub mod app;
 pub mod components;
 pub mod headless;

--- a/apps/tui-node/src/elm/update.rs
+++ b/apps/tui-node/src/elm/update.rs
@@ -888,7 +888,7 @@ pub fn update(model: &mut Model, msg: Message) -> Option<Command> {
             error!("Signing ceremony {} failed: {}", request_id, error);
             model.ui_state.modal = Some(Modal::Error {
                 title: "Signing Failed".to_string(),
-                message: error,
+                message: crate::elm::error_help::signing(&error),
             });
             // Clear pending-sign state so a retry starts clean.
             model.wallet_state.pending_sign_message = None;
@@ -1202,10 +1202,8 @@ pub fn update(model: &mut Model, msg: Message) -> Option<Command> {
             // produce nonsense, so we must block the flow until the user
             // either retries or navigates away.
             error!("Wallet unlock failed: {}", error);
-            model.ui_state.modal = Some(Modal::Error {
-                title: "Unlock Failed".to_string(),
-                message: error,
-            });
+            let (title, message) = crate::elm::error_help::unlock(&error);
+            model.ui_state.modal = Some(Modal::Error { title, message });
             // Critical: clear any pending signing state so a subsequent
             // DKG-creator PasswordPrompt submit isn't hijacked into
             // UnlockWallet on this-failed wallet_id. Without this,
@@ -1434,7 +1432,7 @@ pub fn update(model: &mut Model, msg: Message) -> Option<Command> {
             // Show error modal - always stay on current screen so user can retry or press Esc to go back
             model.ui_state.modal = Some(Modal::Error {
                 title: "DKG Failed".to_string(),
-                message: error,
+                message: crate::elm::error_help::dkg(&error),
             });
 
             // Reset DKG-in-progress flag so user can retry


### PR DESCRIPTION
Continues the error-UX work onto the two remaining hand-poked surfaces — the `serve` JSONL daemon and the TUI — so投资人乱实验时每个失败都给"出错+原因+下一步"。

## serve (JSONL daemon)
- **`bad_request`** now shows a concrete example + points to `mpc-wallet-cli schema`:
  ```json
  {"event":"error","code":"bad_request","message":"invalid JSONL command: … Expected one JSON object per line, e.g. {\"cmd\":\"create_wallet\",…}. Run `mpc-wallet-cli schema` for the full command list."}
  ```
- **`connect` on a roomless hosted server** emits a `room_required` event in-band (that connection is rejected by the multi-tenant server, so the operator learns why instead of every later command hanging):
  ```json
  {"event":"error","code":"room_required","message":"no room set for the hosted server (wss://panda.qzz.io). It requires a strong room (≥16 chars) … Restart `serve` with --room <id> …"}
  ```

## TUI
New `elm::error_help` classifies raw/internal errors and appends guidance (keyword-based, conservative — **always keeps the original text**), wired at the display chokepoints:
- **DKG Failed** → "all participants online in the same room, unique device ids, check network / room / signal server".
- **Signing Failed** → "a quorum (threshold) must approve; enough co-signers online in the room".
- **Unlock Failed** → classifies **wrong password** vs **wallet not found** vs **corrupt**, each with a specific title + next step.
- **"Signal server not connected"** (4 sites) → room/network/LAN guidance instead of "wait for reconnect".

## Verified
- `tui-node` `error_help` unit tests (4) + `mpc-wallet-cli` unit tests (31) pass.
- Live: serve emits `room_required` and the improved `bad_request`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)