### PR TITLE
fix(ext): actionable popup error messages (投资人友好) (#33)

### DIFF
--- a/apps/browser-extension/src/components/CreateWalletForm.svelte
+++ b/apps/browser-extension/src/components/CreateWalletForm.svelte
@@ -11,6 +11,7 @@
     import { MESSAGE_TYPES } from "@mpc-wallet/types/messages";
     import Button from "../lib/ui/Button.svelte";
     import Icon from "../lib/ui/Icon.svelte";
+    import { guideError } from "../utils/error-guidance";
 
     let showAdvanced = false;
 
@@ -56,11 +57,13 @@
             if (response?.success && response.sessionId) {
                 dispatch("created", { sessionId: response.sessionId });
             } else {
-                errorMessage =
-                    response?.error ?? "Failed to create wallet (no error returned)";
+                errorMessage = guideError(
+                    response?.error ?? "Failed to create wallet (no error returned)",
+                    "dkg",
+                );
             }
         } catch (e) {
-            errorMessage = (e as Error).message ?? String(e);
+            errorMessage = guideError((e as Error).message ?? String(e), "dkg");
         } finally {
             submitting = false;
         }

--- a/apps/browser-extension/src/components/Settings.svelte
+++ b/apps/browser-extension/src/components/Settings.svelte
@@ -39,7 +39,7 @@
             return;
         }
         if (!(await setRoom(r))) {
-            roomStatus = "✗ Save failed.";
+            roomStatus = "✗ Save failed — couldn't write to extension storage. Reload the extension and try again.";
             return;
         }
         // Apply immediately: the startup WS connect is roomless (it ran before a

--- a/apps/browser-extension/src/entrypoints/popup/App.svelte
+++ b/apps/browser-extension/src/entrypoints/popup/App.svelte
@@ -11,6 +11,7 @@
     import Button from "../../lib/ui/Button.svelte";
     import Modal from "../../lib/ui/Modal.svelte";
     import CopyButton from "../../lib/ui/CopyButton.svelte";
+    import { guideError } from "../../utils/error-guidance";
     import Collapsible from "../../lib/ui/Collapsible.svelte";
     import { storage } from "#imports";
     import type { AppState } from "@mpc-wallet/types/appstate";
@@ -433,7 +434,10 @@
 //                 console.log("[UI] Processing wsStatus:", message);
                 appState.wsConnected = message.connected || false;
                 if (!message.connected && message.reason) {
-                    appState.wsError = `WebSocket disconnected: ${message.reason}`;
+                    appState.wsError = guideError(
+                        `Disconnected from the signal server: ${message.reason}`,
+                        "connection",
+                    );
                 } else if (message.connected) {
                     appState.wsError = "";
                 }
@@ -452,7 +456,7 @@
 
             case "wsError":
 //                 console.log("[UI] Processing wsError:", message);
-                appState.wsError = message.error;
+                appState.wsError = guideError(message.error, "connection");
                 console.error("[UI] WebSocket error:", message.error);
                 // Trigger reactivity
                 appState = { ...appState };
@@ -816,10 +820,10 @@
                 showSignForm = false;
                 signMessage = "";
             } else {
-                signError = response?.error ?? "Sign failed";
+                signError = guideError(response?.error ?? "Sign failed", "signing");
             }
         } catch (e) {
-            signError = (e as Error).message ?? String(e);
+            signError = guideError((e as Error).message ?? String(e), "signing");
         } finally {
             signing_ = false;
         }

--- a/apps/browser-extension/src/utils/error-guidance.ts
+++ b/apps/browser-extension/src/utils/error-guidance.ts
@@ -1,0 +1,69 @@
+// User-facing error guidance for the popup.
+//
+// Turns a raw/internal error string into something an investor fumbling the live
+// demo can act on: the original error + the most likely cause + the next step.
+// Keyword-based and conservative — when we recognise a cause we say something
+// specific, otherwise we keep the raw error and add general "what to check"
+// guidance. We never drop the original text.
+
+export type ErrorContext = "connection" | "dkg" | "signing" | "keystore";
+
+const ROOM_HINT =
+    "Set a strong room (≥16 chars) in Settings ⚙ — the SAME on every device — then reconnect.";
+
+/** Append actionable guidance to a raw error, based on `context` + keywords. */
+export function guideError(raw: unknown, context: ErrorContext): string {
+    const err = (raw == null ? "" : String(raw)).trim();
+    const lc = err.toLowerCase();
+    let hint = "";
+
+    switch (context) {
+        case "connection":
+            if (lc.includes("room") || lc.includes("400") || lc.includes("rejected") || lc.includes("unauthor")) {
+                hint = `No / weak room. ${ROOM_HINT}`;
+            } else {
+                hint =
+                    "Check your network and the signal server in Settings ⚙. The hosted server also " +
+                    "requires a strong room (≥16 chars).";
+            }
+            break;
+        case "dkg":
+            if (lc.includes("connect") || lc.includes("offline") || lc.includes("signal") || lc.includes("websocket")) {
+                hint = `Couldn't reach the signal server. ${ROOM_HINT}`;
+            } else if (lc.includes("timeout") || lc.includes("timed out") || lc.includes("waiting")) {
+                hint =
+                    "All participants must be online together in the SAME room, each with a unique device id.";
+            } else if (lc.includes("room")) {
+                hint = ROOM_HINT;
+            } else {
+                hint = "Make sure every participant is online in the same room with a unique device id.";
+            }
+            break;
+        case "signing":
+            if (lc.includes("timeout") || lc.includes("timed out") || lc.includes("waiting")) {
+                hint =
+                    "A quorum (the threshold) must approve. Make sure enough co-signers are online in " +
+                    "the same room and approved the request.";
+            } else if (lc.includes("password") || lc.includes("unlock") || lc.includes("decrypt")) {
+                hint = "Wrong password for this wallet — enter the password you set on this device.";
+            } else if (lc.includes("not found")) {
+                hint = "Wallet/account not found on this device — pick the right one.";
+            } else if (lc.includes("connect") || lc.includes("offline") || lc.includes("signal")) {
+                hint = `Couldn't reach the signal server / co-signers. ${ROOM_HINT}`;
+            } else {
+                hint =
+                    "Check at least the threshold number of co-signers are online in the same room and approved.";
+            }
+            break;
+        case "keystore":
+            if (lc.includes("password") || lc.includes("decrypt") || lc.includes("mac") || lc.includes("invalid")) {
+                hint = "Wrong password, or the file isn't a matching keystore. Re-check the password.";
+            } else {
+                hint = "Check the file is a valid keystore export and the password is correct.";
+            }
+            break;
+    }
+
+    if (!err) return hint;
+    return hint ? `${err}\n→ ${hint}` : err;
+}

--- a/apps/browser-extension/tests/utils/error-guidance.test.ts
+++ b/apps/browser-extension/tests/utils/error-guidance.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "bun:test";
+import { guideError } from "../../src/utils/error-guidance";
+
+describe("guideError", () => {
+    it("keeps the raw error and appends a hint", () => {
+        const out = guideError("boom", "connection");
+        expect(out).toContain("boom");
+        expect(out).toContain("→");
+    });
+
+    it("connection: a 400/rejected points at the room", () => {
+        expect(guideError("WebSocket 400", "connection").toLowerCase()).toContain("room");
+        expect(guideError("connection rejected", "connection").toLowerCase()).toContain("room");
+    });
+
+    it("dkg: connection-ish errors point at server+room; timeouts at participants", () => {
+        expect(guideError("signal server offline", "dkg").toLowerCase()).toContain("signal server");
+        expect(guideError("timed out after 90s", "dkg").toLowerCase()).toContain("same room");
+    });
+
+    it("signing: timeout → quorum; password → wrong password", () => {
+        expect(guideError("timed out", "signing").toLowerCase()).toContain("quorum");
+        expect(guideError("invalid password", "signing").toLowerCase()).toContain("wrong password");
+    });
+
+    it("keystore: bad password is recognised", () => {
+        expect(guideError("decrypt failed", "keystore").toLowerCase()).toContain("password");
+    });
+
+    it("empty error yields just the hint (no leading separator)", () => {
+        const out = guideError("", "connection");
+        expect(out.startsWith("→")).toBe(false);
+        expect(out.length).toBeGreaterThan(0);
+    });
+
+    it("null/undefined are handled", () => {
+        expect(() => guideError(null, "dkg")).not.toThrow();
+        expect(() => guideError(undefined, "signing")).not.toThrow();
+    });
+});


### PR DESCRIPTION
最后一个手动接触面:**浏览器扩展 popup**。和 CLI(#69)、serve/TUI(#70)一样,失败都改成"出错 + 原因 + 下一步",并保留原始报错。

The last hand-poked surface. Same treatment as CLI (#69) and serve/TUI (#70).

## What changed
- **New `src/utils/error-guidance.ts`** — `guideError(raw, context)`: keyword-based, conservative, **always keeps the original error** and appends a hint. Contexts: `connection` / `dkg` / `signing` / `keystore`.
- Wired at the popup's user-visible error chokepoints:
  - **Connection** (`App.svelte` wsStatus-disconnect + `wsError` banner) → network / signal-server / **strong room (≥16 chars)** guidance.
  - **Signing** (`App.svelte` `signError`) → quorum / wrong-password / room guidance.
  - **DKG create** (`CreateWalletForm.svelte` failure + catch) → "all participants online, same room, unique device id".
  - **Settings** "Save failed" room message now explains the cause + suggests reload.

## Verified
- `guideError` unit tests (7) pass.
- Full extension suite green (**525 pass, 0 fail**); `bun run build` OK.
- (Live popup behaviour can't run in this sandbox — no browser/display; covered by the unit tests + the #33 interop harness on a real runner.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)