### PR TITLE
fix(cli): clean one-line errors, no Rust backtrace

### DIFF
--- a/apps/cli-node/src/main.rs
+++ b/apps/cli-node/src/main.rs
@@ -281,7 +281,18 @@ struct ServeArgs {
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() {
+    // Single clean exit point: print the error chain as one line and exit 1 —
+    // no Rust "Error: …" + stack backtrace in a user's face (and consistent with
+    // the `finish()` one-shot paths). `{:#}` renders anyhow's full cause chain
+    // on one line without a backtrace, even when RUST_BACKTRACE is set.
+    if let Err(e) = run().await {
+        eprintln!("error: {e:#}");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> anyhow::Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Command::Schema => {


### PR DESCRIPTION
While testing abnormal CLI commands (to confirm the new error messages actually surface), I hit a real inconsistency: commands that go through `finish()` printed a clean `error: …` and exit 1, but commands that propagate with `?` straight out of `main` (`simulate`, `reshare-simulate`, `--password-file` resolution, `serve`) were rendered by Rust's default `fn main() -> Result` as `Error: <Debug>` **+ a full stack backtrace** — scary noise (worse with `RUST_BACKTRACE=1`).

**Before**
```
$ mpc-wallet-cli simulate --nodes 1
Error: need at least 2 nodes

Stack backtrace:
   0: anyhow::error::<impl anyhow::Error>::msg
   1: anyhow::__private::format_err
   … 25 frames …
```
**After**
```
$ mpc-wallet-cli simulate --nodes 1
error: need at least 2 nodes        # exit 1, no backtrace
```

Fix: `main` is now a thin wrapper over `run() -> Result` that prints `error: {e:#}` (anyhow's full cause chain on one line, no backtrace) and exits 1 — uniform with the `finish()` paths.

Verified across the abnormal-command battery — all clean, exit 1:
- `simulate --nodes 1` / `--threshold 5 --nodes 3` / `--curve dogecoin`
- `reshare-simulate --threshold 5 --nodes 3`
- `sign --password-file /missing`
- connection timeouts (no room → room hint; unreachable server → network hint)
- clap usage errors + serve `bad_request` / `room_required` (unchanged, already clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)