### PR TITLE
fix(dkg): cleaner, higher-entropy wallet id derivation

### DIFF
--- a/apps/tui-node/src/elm/update.rs
+++ b/apps/tui-node/src/elm/update.rs
@@ -1587,12 +1587,13 @@ pub fn update(model: &mut Model, msg: Message) -> Option<Command> {
 
                 // Wallet name is derived from the session so every participant
                 // ends up with the same identifier — required for cross-device
-                // signing coordination later. Same formula as `dkg.rs:661`
-                // uses to seed `current_wallet_id`.
+                // signing coordination later. Shared derivation with `dkg.rs`
+                // (`wallet_id_from_session`) so the persisted id matches the
+                // in-memory `current_wallet_id` seeded post-part3.
                 let wallet_name = model
                     .active_session
                     .as_ref()
-                    .map(|s| format!("wallet-{}", &s.session_id[..8.min(s.session_id.len())]));
+                    .map(|s| crate::protocal::dkg::wallet_id_from_session(&s.session_id));
 
                 // Optional user-chosen display label (creator typed it on the
                 // password screen). Empty → None → UI falls back to the id.

--- a/apps/tui-node/src/protocal/dkg.rs
+++ b/apps/tui-node/src/protocal/dkg.rs
@@ -52,6 +52,31 @@ pub(crate) fn canonical_identifier<C: Ciphersuite>(
     Identifier::<C>::try_from(one_based).ok()
 }
 
+/// Derive the persisted wallet id from a DKG session id.
+///
+/// The session id is `dkg_<uuid>` — random, and **identical across all
+/// participants** (the creator mints it and joiners adopt it), so this mapping
+/// is deterministic cluster-wide: every device computes the same wallet id. We
+/// strip the `dkg_` prefix and keep 12 hex chars — enough entropy that two
+/// wallets in one room don't collide, and no `dkg_` noise inside the id (e.g.
+/// session `dkg_d9f249e9-66b3-4ee8-…` → `wallet-d9f249e966b3`). Non-standard
+/// session ids fall back to a sanitized slice so we always produce a valid id.
+///
+/// MUST be the single source of truth for this mapping — both the in-memory
+/// `current_wallet_id` (here, post-part3) and the persisted wallet id
+/// (`FinalizeWalletFromDkg`) call this, and they have to agree.
+pub fn wallet_id_from_session(session_id: &str) -> String {
+    let core = session_id.strip_prefix("dkg_").unwrap_or(session_id);
+    let hex: String = core.chars().filter(|c| c.is_ascii_hexdigit()).take(12).collect();
+    let token = if hex.len() >= 8 {
+        hex
+    } else {
+        let s: String = core.chars().filter(|c| c.is_ascii_alphanumeric()).take(12).collect();
+        if s.is_empty() { "default".to_string() } else { s }
+    };
+    format!("wallet-{token}")
+}
+
 // Removed insecure derive_group_key function - now using real FROST DKG output.
 //
 // `handle_trigger_dkg_round1_dynamic` used to live here as a dispatch helper
@@ -663,12 +688,13 @@ where
         // Complete DKG
         guard.dkg_state = DkgState::Complete;
         
-        // Generate wallet ID
-        let wallet_id = if let Some(session) = &guard.session {
-            format!("wallet-{}", &session.session_id[..8])
-        } else {
-            "wallet-default".to_string()
-        };
+        // Generate wallet ID (shared derivation — see `wallet_id_from_session`;
+        // must match the persisted id in `FinalizeWalletFromDkg`).
+        let wallet_id = guard
+            .session
+            .as_ref()
+            .map(|s| wallet_id_from_session(&s.session_id))
+            .unwrap_or_else(|| "wallet-default".to_string());
         guard.current_wallet_id = Some(wallet_id.clone());
         
         // Log the real group public key
@@ -870,4 +896,42 @@ pub fn aggregate_signature<C: Ciphersuite>(
 pub fn generate_signing_commitment<C: Ciphersuite>(
 ) -> Result<frost_core::round1::SigningCommitments<C>, Box<dyn std::error::Error + Send + Sync>> {
     Err("Signing commitment generation is temporarily stubbed".into())
+}
+#[cfg(test)]
+mod wallet_id_tests {
+    use super::wallet_id_from_session;
+
+    #[test]
+    fn strips_dkg_prefix_and_keeps_12_hex() {
+        assert_eq!(
+            wallet_id_from_session("dkg_d9f249e9-66b3-4ee8-8a2d-16db1e6cbb1d"),
+            "wallet-d9f249e966b3"
+        );
+    }
+
+    #[test]
+    fn distinct_sessions_distinct_ids() {
+        let a = wallet_id_from_session("dkg_d9f249e9-66b3-4ee8-8a2d-16db1e6cbb1d");
+        let b = wallet_id_from_session("dkg_3a17c0de-1111-2222-3333-444455556666");
+        assert_ne!(a, b);
+        assert!(a.starts_with("wallet-") && b.starts_with("wallet-"));
+    }
+
+    #[test]
+    fn deterministic() {
+        let s = "dkg_abcdef0123456789-aaaa";
+        assert_eq!(wallet_id_from_session(s), wallet_id_from_session(s));
+    }
+
+    #[test]
+    fn no_dkg_substring_in_id() {
+        assert!(!wallet_id_from_session("dkg_d9f249e9-66b3").contains("dkg_"));
+    }
+
+    #[test]
+    fn short_or_weird_session_does_not_panic() {
+        assert!(wallet_id_from_session("x").starts_with("wallet-"));
+        assert!(wallet_id_from_session("").starts_with("wallet-"));
+        assert!(wallet_id_from_session("dkg_").starts_with("wallet-"));
+    }
 }


### PR DESCRIPTION
Follow-up to your naming question. The persisted wallet id was `format!("wallet-{}", &session_id[..8])` with `session_id = dkg_<uuid>`, so it came out like **`wallet-dkg_d9f2`** — it baked in the `dkg_` prefix and kept only ~16 bits of the uuid (4 hex chars): ugly, and a real (if small) collision risk for several wallets in one room. The formula was also duplicated across two sites.

**Now** a single source of truth `dkg::wallet_id_from_session` strips `dkg_` and keeps 12 hex chars:
```
dkg_d9f249e9-66b3-4ee8-8a2d-16db1e6cbb1d  →  wallet-d9f249e966b3   (48 bits)
```
- Deterministic cluster-wide (pure fn of the shared session id → all participants agree).
- Panic-safe on short/odd ids.
- Both derivation sites (`current_wallet_id` post-part3 in `dkg.rs`, and the persisted id in `FinalizeWalletFromDkg`) call it.
- **Existing wallets on disk are unaffected** (the id is stored, not recomputed); only newly-created wallets get the cleaner id.

Tests: 5 unit tests for the derivation; tui-node lib (98) + the reshare e2e (create→reshare→sign by wallet_id) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)