### PR TITLE
fix(dkg): drop the meaningless wallet- prefix from wallet ids

### DIFF
--- a/apps/tui-node/src/protocal/dkg.rs
+++ b/apps/tui-node/src/protocal/dkg.rs
@@ -58,9 +58,10 @@ pub(crate) fn canonical_identifier<C: Ciphersuite>(
 /// participants** (the creator mints it and joiners adopt it), so this mapping
 /// is deterministic cluster-wide: every device computes the same wallet id. We
 /// strip the `dkg_` prefix and keep 12 hex chars — enough entropy that two
-/// wallets in one room don't collide, and no `dkg_` noise inside the id (e.g.
-/// session `dkg_d9f249e9-66b3-4ee8-…` → `wallet-d9f249e966b3`). Non-standard
-/// session ids fall back to a sanitized slice so we always produce a valid id.
+/// wallets in one room don't collide (e.g. session `dkg_d9f249e9-66b3-4ee8-…` →
+/// `d9f249e966b3`). The id is the bare token: no `wallet-`/`dkg_` noise (the
+/// prefix carried no information). Non-standard session ids fall back to a
+/// sanitized slice so we always produce a non-empty, filesystem-safe id.
 ///
 /// MUST be the single source of truth for this mapping — both the in-memory
 /// `current_wallet_id` (here, post-part3) and the persisted wallet id
@@ -68,13 +69,11 @@ pub(crate) fn canonical_identifier<C: Ciphersuite>(
 pub fn wallet_id_from_session(session_id: &str) -> String {
     let core = session_id.strip_prefix("dkg_").unwrap_or(session_id);
     let hex: String = core.chars().filter(|c| c.is_ascii_hexdigit()).take(12).collect();
-    let token = if hex.len() >= 8 {
-        hex
-    } else {
-        let s: String = core.chars().filter(|c| c.is_ascii_alphanumeric()).take(12).collect();
-        if s.is_empty() { "default".to_string() } else { s }
-    };
-    format!("wallet-{token}")
+    if hex.len() >= 8 {
+        return hex;
+    }
+    let s: String = core.chars().filter(|c| c.is_ascii_alphanumeric()).take(12).collect();
+    if s.is_empty() { "wallet".to_string() } else { s }
 }
 
 // Removed insecure derive_group_key function - now using real FROST DKG output.
@@ -694,7 +693,7 @@ where
             .session
             .as_ref()
             .map(|s| wallet_id_from_session(&s.session_id))
-            .unwrap_or_else(|| "wallet-default".to_string());
+            .unwrap_or_else(|| "wallet".to_string());
         guard.current_wallet_id = Some(wallet_id.clone());
         
         // Log the real group public key
@@ -902,10 +901,10 @@ mod wallet_id_tests {
     use super::wallet_id_from_session;
 
     #[test]
-    fn strips_dkg_prefix_and_keeps_12_hex() {
+    fn strips_dkg_prefix_keeps_12_hex_no_prefix() {
         assert_eq!(
             wallet_id_from_session("dkg_d9f249e9-66b3-4ee8-8a2d-16db1e6cbb1d"),
-            "wallet-d9f249e966b3"
+            "d9f249e966b3"
         );
     }
 
@@ -914,7 +913,6 @@ mod wallet_id_tests {
         let a = wallet_id_from_session("dkg_d9f249e9-66b3-4ee8-8a2d-16db1e6cbb1d");
         let b = wallet_id_from_session("dkg_3a17c0de-1111-2222-3333-444455556666");
         assert_ne!(a, b);
-        assert!(a.starts_with("wallet-") && b.starts_with("wallet-"));
     }
 
     #[test]
@@ -924,14 +922,17 @@ mod wallet_id_tests {
     }
 
     #[test]
-    fn no_dkg_substring_in_id() {
-        assert!(!wallet_id_from_session("dkg_d9f249e9-66b3").contains("dkg_"));
+    fn no_dkg_or_wallet_noise_in_id() {
+        let id = wallet_id_from_session("dkg_d9f249e9-66b3");
+        assert!(!id.contains("dkg_") && !id.contains("wallet-"));
     }
 
     #[test]
-    fn short_or_weird_session_does_not_panic() {
-        assert!(wallet_id_from_session("x").starts_with("wallet-"));
-        assert!(wallet_id_from_session("").starts_with("wallet-"));
-        assert!(wallet_id_from_session("dkg_").starts_with("wallet-"));
+    fn short_or_weird_session_is_nonempty_and_safe() {
+        for s in ["x", "", "dkg_"] {
+            let id = wallet_id_from_session(s);
+            assert!(!id.is_empty());
+            assert!(id.chars().all(|c| c.is_ascii_alphanumeric()));
+        }
     }
 }


### PR DESCRIPTION
Per feedback ("这个前缀也没啥意义吧"): the `wallet-` prefix carried no information — nothing in the workspace parses it (verified: no `starts_with("wallet-")`/`strip_prefix`, all other `"wallet-…"` literals are test fixtures or CSS class names). So the wallet id is now the bare derived token:
```
dkg_d9f249e9-66b3-4ee8-8a2d-16db1e6cbb1d  →  d9f249e966b3      (was: wallet-d9f249e966b3)
```
- `wallet_id_from_session` returns the 12-hex token directly; degenerate/non-uuid session ids fall back to a sanitized, non-empty, filesystem-safe token.
- **Existing wallets on disk keep their stored ids** (id is stored, not recomputed); only newly-created wallets use the bare form.
- Tests updated (5); reshare e2e (create→reshare→sign by id) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)