### PR TITLE
fix(dkg): drop the dkg_ prefix from session ids

### DIFF
--- a/apps/tui-node/src/elm/command.rs
+++ b/apps/tui-node/src/elm/command.rs
@@ -603,8 +603,12 @@ impl Command {
                             info!("🔄 Reusing existing session ID: {}", session.session_id);
                             session.session_id.clone()
                         } else {
-                            // Only generate new session ID if we don't have one
-                            let new_id = format!("dkg_{}", uuid::Uuid::new_v4());
+                            // Only generate new session ID if we don't have one.
+                            // Bare UUID — the session TYPE is carried in the
+                            // `session_type` field, not parsed from an id prefix,
+                            // so a `dkg_` prefix was just noise. (wallet ids derive
+                            // from the hex either way; see wallet_id_from_session.)
+                            let new_id = uuid::Uuid::new_v4().to_string();
                             info!("🆕 Creating new session ID: {}", new_id);
                             new_id
                         }


### PR DESCRIPTION
Per feedback ("session id also do not need dkg_"). DKG session ids were `dkg_<uuid>`; the prefix carries no routing meaning — the session **type** is in the `session_type` field, and nothing parses the id prefix (the only `dkg_` strip is `wallet_id_from_session`, kept harmless / now a no-op for new ids). New DKG sessions use a bare UUID:
```
note: session id = 04e8ea3e-6ecc-4a3a-820b-2321035434df     (was: dkg_04e8ea3e-…)
  → mpc-wallet-cli session join --session-id 04e8ea3e-… --room … --device-id <unique>
```
- wallet ids unchanged (derived by filtering hex from the session id either way).
- Legacy `dkg_`-prefixed ids still strip correctly (backward compatible).
- `simulate` (full DKG+sign) and the reshare e2e (create→reshare→sign by id) pass.

(`sign_`/`reshare_` transient ids left as-is — they're operation-scoped log hints; say the word and I'll drop those too.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)