### PR TITLE
fix(cli): joiner must request session replay (cold-start discovery)

### DIFF
--- a/apps/cli-node/src/oneshot.rs
+++ b/apps/cli-node/src/oneshot.rs
@@ -306,13 +306,32 @@ pub async fn session_join(
     let (tx, mut rx, roster) = start(&opts);
     tx.send(Message::TriggerReconnect)?;
     wait_connected(&mut rx, &opts).await?;
-    // Give the server a moment to replay the session, then join.
-    tokio::time::sleep(Duration::from_secs(3)).await;
-    tx.send(Message::HeadlessJoinSession {
-        session_id,
-        password,
-        label: String::new(),
-    })?;
+    // Cold-start discovery + join. The creator almost always announces the
+    // session BEFORE we connect, and `announce_session` is a one-shot broadcast,
+    // so we must ask the server to replay active sessions
+    // (`HeadlessRefreshSessions` → `RequestActiveSessions`) — otherwise we never
+    // discover the session and silently time out (the bug investors hit). We
+    // retry refresh→join on a short cadence to beat the announce/connect race in
+    // EITHER order; `HeadlessJoinSession` is idempotent once joined, so the
+    // repeats are harmless no-ops after the mesh forms.
+    {
+        let tx_join = tx.clone();
+        let sid = session_id.clone();
+        let pw = password.clone();
+        let attempts = (opts.timeout_secs / 6).clamp(5, 12);
+        tokio::spawn(async move {
+            for _ in 0..attempts {
+                let _ = tx_join.send(Message::HeadlessRefreshSessions);
+                tokio::time::sleep(Duration::from_millis(700)).await;
+                let _ = tx_join.send(Message::HeadlessJoinSession {
+                    session_id: sid.clone(),
+                    password: pw.clone(),
+                    label: String::new(),
+                });
+                tokio::time::sleep(Duration::from_secs(2)).await;
+            }
+        });
+    }
     let ev = wait_outcome(
         &mut rx,
         opts.timeout_secs,

--- a/apps/tui-node/src/elm/update.rs
+++ b/apps/tui-node/src/elm/update.rs
@@ -355,6 +355,19 @@ pub fn update(model: &mut Model, msg: Message) -> Option<Command> {
         // Headless joiner entry: pick the discovered invite by id, mark it
         // active (the joiner signal SubmitPassword keys off), then hand off.
         Message::HeadlessJoinSession { session_id, password, label } => {
+            // Idempotent: the CLI joiner retries refresh+join on a short cadence
+            // to beat the announce/connect race (the creator may announce before
+            // we connect, and `announce_session` is a one-shot broadcast). Once
+            // we've already joined this session, ignore repeat sends so we don't
+            // re-fire SubmitPassword and clobber an in-progress DKG.
+            if model
+                .active_session
+                .as_ref()
+                .map(|s| s.session_id.as_str())
+                == Some(session_id.as_str())
+            {
+                return None;
+            }
             match model
                 .session_invites
                 .iter()
@@ -369,8 +382,12 @@ pub fn update(model: &mut Model, msg: Message) -> Option<Command> {
                     }))
                 }
                 None => {
-                    warn!(
-                        "HeadlessJoinSession: no discovered session with id {}",
+                    // Not discovered yet — expected during the cold-start retry
+                    // window before the server's `RequestActiveSessions` replay
+                    // (or the live announce) arrives. Logged at debug so the
+                    // retry cadence doesn't spam an investor's info-level run.
+                    debug!(
+                        "HeadlessJoinSession: session {} not discovered yet, awaiting replay",
                         session_id
                     );
                     None


### PR DESCRIPTION
## The bug investors kept hitting

Multi-device DKG silently timed out after 90s — every time, even with unique device-ids, a strong shared room, and the correct session id. The roster diagnostic (#81) narrowed it to a **complete roster (3/3) that still stalls**, ruling out the device-id footgun.

## Root cause

`session join` connected, slept 3s *"to let the server replay the session"*, then sent `HeadlessJoinSession` **once** — but **nothing ever requested the replay**. `announce_session` is a one-shot broadcast, and the creator almost always announces *before* a joiner connects, so the joiner never discovered the session:

```
WebSocket connected
Updating participants list: ["1", "2"]          # room presence (misleading!)
WARN HeadlessJoinSession: no discovered session with id 219a035d-...
```

The creator's `[1,2,3] (3/3)` roster counts **room presence**, not session-join — which is why it looked complete while the mesh never formed.

`serve.rs`, the `headless.rs` helper, and the browser extension all already fire the cold-start replay; only the CLI one-shot `session join` skipped it.

## The fix

- Fire `HeadlessRefreshSessions` (→ `RequestActiveSessions`) so the server replays active sessions, then join.
- Retry refresh→join on a short cadence to beat the announce/connect race in **either** order.
- Make `HeadlessJoinSession` idempotent (skip if already joined) so the retries are harmless no-ops once the mesh forms.

## Why `simulate` never caught it

`simulate` connects all nodes **first**, then node 0 announces — so joiners are already listening and the cold-start race never happens in-process.

## Verification (real `wss://panda.qzz.io`, separate OS processes — previously always timed out)

- **2-of-2**: both reach `dkg_complete`, identical group key + address, ~6s
- **2-of-3, staggered joins**: all three reach `dkg_complete`, identical address `0xec3241c8…`

🤖 Generated with [Claude Code](https://claude.com/claude-code)