### PR TITLE
feat(demo): add --reshare phase to ceremony.sh (real-process recovery demo)

### DIFF
--- a/docs/DEMO_REHEARSAL_CHECKLIST.md
+++ b/docs/DEMO_REHEARSAL_CHECKLIST.md
@@ -61,7 +61,8 @@ point into it).
        `mpc-wallet-cli reshare --wallet-id <W> --room "$ROOM"` and have the retained signers
        `session join` it → same `group_public_key`, the wallet keeps signing, the dropped
        device's share is dead. The "lose/rotate a device, same address" story. *(No live
-       setup? The resharing engine is verified in `cargo test -p mpc-wallet-cli`.)*
+       setup? `scripts/demo/ceremony.sh --nodes 3 --threshold 2 --reshare` proves it
+       self-contained in one paste → `"group_key_preserved": true`.)*
 
 ## Failure drills (rehearse the recovery, not just the happy path)
 

--- a/docs/DEMO_REHEARSAL_CHECKLIST.zh.md
+++ b/docs/DEMO_REHEARSAL_CHECKLIST.zh.md
@@ -53,7 +53,8 @@ Wi‑Fi 掉线、二进制冷启动）。请配合指南一起使用：[`INVESTO
        `mpc-wallet-cli reshare --wallet-id <W> --room "$ROOM"`，让保留下来的签名方
        `session join` 它 → 相同的 `group_public_key`、钱包继续可签、被移除设备的分片作废。
        即"丢失/轮换一台设备，地址不变"的故事。*（没有现场环境？重新分享引擎已在
-       `cargo test -p mpc-wallet-cli` 中验证。）*
+       `scripts/demo/ceremony.sh --nodes 3 --threshold 2 --reshare` 一条命令即可自包含证明
+       → `"group_key_preserved": true`。）*
 
 ## 故障演练（要彩排恢复流程，而不只是顺利路径）
 

--- a/docs/INVESTOR_GUIDE.md
+++ b/docs/INVESTOR_GUIDE.md
@@ -378,6 +378,10 @@ quorum keeps signing, and every pre-refresh share becomes dead.
 mpc-wallet-cli reshare --wallet-id <W> --room "$ROOM"
 #   → retained signers approve by running `session join` (or `serve --auto-approve`)
 #     on the announced reshare session, exactly like a co-signed transaction.
+
+# …or prove the whole thing self-contained, real separate processes, in one paste:
+scripts/demo/ceremony.sh --nodes 3 --threshold 2 --reshare
+#   → "reshared": true, "group_key_preserved": true  (the address never moved)
 ```
 
 The refresh preserves the invariants you point at:
@@ -392,9 +396,9 @@ The refresh preserves the invariants you point at:
 > attacker collecting fragments over months never assembles a key. A single-key custodial
 > wallet can't do any of that."
 
-> **Proof without a live setup:** the resharing engine (key-preserved refresh, refreshed
-> quorum signs, old share rejected) is verified end to end in the test suite —
-> `cargo test -p mpc-wallet-cli` — alongside the DKG and signing conformance cases. See
+> **Proof without a live setup:** `scripts/demo/ceremony.sh … --reshare` runs the whole
+> refresh across real separate processes and asserts the address is preserved; the engine is
+> also verified in the test suite (`cargo test -p mpc-wallet-cli`). See
 > `docs/RECOVERY_AND_RESHARING.md` for the full threat model + talking points.
 
 ---

--- a/docs/INVESTOR_GUIDE.zh.md
+++ b/docs/INVESTOR_GUIDE.zh.md
@@ -335,6 +335,10 @@ cargo run --release --bin mpc-wallet-tui -p tui-node -- \
 mpc-wallet-cli reshare --wallet-id <W> --room "$ROOM"
 #   → 保留下来的签名方在被广播的 reshare 会话上执行 `session join`
 #     （或 `serve --auto-approve`）来批准，就像一笔多方共签的交易。
+
+# …或者用一条命令、自包含、真实独立进程地证明整个过程：
+scripts/demo/ceremony.sh --nodes 3 --threshold 2 --reshare
+#   → "reshared": true, "group_key_preserved": true（地址从未移动）
 ```
 
 刷新保持了你要指给投资人看的那些不变量：
@@ -346,8 +350,8 @@ mpc-wallet-cli reshare --wallet-id <W> --room "$ROOM"
 > 我们还能按计划定期轮换，这样一个用几个月时间收集碎片的攻击者永远拼不出一把密钥。
 > 单密钥的托管钱包做不到这其中任何一点。"
 
-> **无需现场搭建的证明：** 重新分享引擎（地址不变的刷新、刷新后法定门限签名、旧分片作废）
-> 在测试套件里被端到端验证 —— `cargo test -p mpc-wallet-cli` —— 与 DKG 和签名的一致性用例一起。
+> **无需现场搭建的证明：** `scripts/demo/ceremony.sh … --reshare` 在真实的独立进程上跑完
+> 整个刷新，并断言地址保持不变；该引擎同时也在测试套件里被验证（`cargo test -p mpc-wallet-cli`）。
 > 完整的威胁模型 + 话术见 `docs/RECOVERY_AND_RESHARING.md`。
 
 ---

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -292,8 +292,8 @@ mpc-wallet-cli serve   --device-id <id> --keystore <dir> --signal-server wss://p
 mpc-wallet-cli wallet  create --name w --threshold 2 --total 3 --curve secp256k1 --room "$ROOM" --device-id <id> --password-file <f>
 mpc-wallet-cli sign    --wallet-id <id> --message hi --room "$ROOM" --device-id <id> --password-file <f>
 
-# Self-contained end-to-end smoke test (real multi-process DKG + signing over a local server):
-scripts/demo/ceremony.sh --nodes 3 --threshold 2 --sign hi   # add --signal wss://… --room "$ROOM" to test a hosted server
+# Self-contained end-to-end smoke test (real multi-process DKG + signing + reshare over a local server):
+scripts/demo/ceremony.sh --nodes 3 --threshold 2 --sign hi --reshare   # add --signal wss://… --room "$ROOM" for a hosted server
 
 # TUI
 mpc-wallet-tui --device-id <id> --signal-server wss://panda.qzz.io --room "$ROOM" [--offline]

--- a/scripts/demo/ceremony.sh
+++ b/scripts/demo/ceremony.sh
@@ -2,13 +2,15 @@
 # ceremony.sh — run a REAL multi-process MPC ceremony end to end.
 #
 # This drives the ACTUAL `mpc-wallet-cli` as separate OS processes: a creator
-# (`wallet create`) plus N-1 joiners (`session join`) for DKG, then — with
-# --sign — an initiator (`sign`) plus a quorum of co-signers (`serve
-# --auto-approve`) for threshold signing. Every node is its own process with
-# its own on-disk keystore, talking over real WebRTC through a real signal
-# server. Nothing is simulated in one address space, so there is nothing
-# hard-coded to fake — which is exactly what makes it convincing on stage (and
-# a faithful smoke test of the same path a live demo uses).
+# (`wallet create`) plus N-1 joiners (`session join`) for DKG, then —
+#   --sign     an initiator (`sign`) + a quorum of co-signers (`serve
+#              --auto-approve`) produce a threshold signature;
+#   --reshare  the wallet holder (`reshare`) + the retained signers refresh
+#              every share — same address, fresh shares, old shares dead.
+# Every node is its own process with its own on-disk keystore, talking over real
+# WebRTC through a real signal server. Nothing is simulated in one address space,
+# so there is nothing hard-coded to fake — which is exactly what makes it
+# convincing on stage (and a faithful smoke test of the live demo path).
 #
 # By default it spins up a LOCAL signal server on loopback, so the whole thing
 # is self-contained and needs no network — the "cannot fail" fallback. Point it
@@ -18,21 +20,23 @@
 # Usage:
 #   scripts/demo/ceremony.sh [--nodes N] [--threshold T]
 #                            [--curve secp256k1|ed25519]
-#                            [--sign "message to sign"]
+#                            [--sign "message to sign"] [--reshare]
 #                            [--signal ws[s]://host[:port]] [--room ID]
 #                            [--timeout SECONDS] [--keep]
 #
 # Exit 0 iff every node agreed on ONE group key (and, with --sign, the quorum
-# produced a signature). Prints a JSON summary on success.
+# produced a signature; with --reshare, the refresh preserved the address).
+# Prints a JSON summary on success.
 set -euo pipefail
 
-NODES=3 THRESH=2 CURVE=secp256k1 SIGN_MSG="" SIGNAL="" ROOM="" TIMEOUT=90 KEEP=0
+NODES=3 THRESH=2 CURVE=secp256k1 SIGN_MSG="" RESHARE=0 SIGNAL="" ROOM="" TIMEOUT=90 KEEP=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --nodes)     NODES="$2"; shift 2 ;;
     --threshold) THRESH="$2"; shift 2 ;;
     --curve)     CURVE="$2"; shift 2 ;;
     --sign)      SIGN_MSG="$2"; shift 2 ;;
+    --reshare)   RESHARE=1; shift ;;
     --signal)    SIGNAL="$2"; shift 2 ;;
     --room)      ROOM="$2"; shift 2 ;;
     --timeout)   TIMEOUT="$2"; shift 2 ;;
@@ -95,6 +99,31 @@ fi
 # field <file> <json-key> — pull a string value out of an event line
 field() { grep -oE "\"$2\": *\"[^\"]+\"" "$1" 2>/dev/null | head -1 | sed -E 's/.*: *"([^"]+)"/\1/'; }
 
+# Co-signer daemons (`serve --auto-approve`) approve BOTH signing and reshare
+# requests. `serve` is a JSONL daemon: it connects only when told, then exits on
+# stdin EOF — so we feed it one `connect` command and HOLD stdin open with a
+# trailing sleep. start_cosigners <indices…> launches one per node index;
+# stop_cosigners tears them down so the next phase can reuse those device-ids
+# (the signal server rejects a duplicate id, so phases must not overlap).
+COSIGNER_PIDS=()
+start_cosigners() {
+  COSIGNER_PIDS=()
+  for ci in "$@"; do
+    "$CLI" serve --auto-approve --approve-password-file "$PW" --curve "$CURVE" \
+      --device-id "$ci" --keystore "$WORK/ks-$ci" \
+      --signal-server "$SIGNAL" "${ROOM_FLAG[@]}" \
+      >"$WORK/serve-$ci.out" 2>"$WORK/serve-$ci.log" \
+      < <(printf '{"cmd":"connect"}\n'; sleep "$((TIMEOUT + 15))") &
+    COSIGNER_PIDS+=("$!"); PIDS+=("$!")
+  done
+  sleep 2  # let the daemons connect + replay the active session list
+}
+stop_cosigners() {
+  for cp in "${COSIGNER_PIDS[@]:-}"; do kill "$cp" 2>/dev/null || true; done
+  COSIGNER_PIDS=()
+  sleep 1  # let the server register the disconnects before ids are reused
+}
+
 echo
 c_dim "▸ DKG ${THRESH}-of-${NODES} (${CURVE}) over ${SIGNAL} — ${NODES} separate processes"
 
@@ -136,39 +165,50 @@ done
 c_ok "  ✅ DKG complete — all ${NODES} nodes agree on one group key"
 
 SIG_HEX=""; MSG_HASH=""
-# --- Phase 2: threshold signing (optional) ---
+# --- Phase 2: threshold signing (optional) — initiator + (T-1) co-signers ---
 if [ -n "$SIGN_MSG" ]; then
   echo
   c_dim "▸ signing \"${SIGN_MSG}\" — initiator + $((THRESH - 1)) co-signer(s) (serve --auto-approve)"
-  # `serve` is a JSONL daemon: it reads commands on stdin, connects only when
-  # told to, auto-approves the signing request on its own, and exits on EOF. So
-  # we feed it a single `connect` command and then HOLD stdin open (the trailing
-  # sleep) so it neither sits disconnected nor quits before the ceremony ends.
-  for i in $(seq 2 "$THRESH"); do
-    "$CLI" serve --auto-approve --approve-password-file "$PW" --curve "$CURVE" \
-      --device-id "$i" --keystore "$WORK/ks-$i" \
-      --signal-server "$SIGNAL" "${ROOM_FLAG[@]}" \
-      >"$WORK/serve-$i.out" 2>"$WORK/serve-$i.log" \
-      < <(printf '{"cmd":"connect"}\n'; sleep "$((TIMEOUT + 15))") &
-    PIDS+=("$!")
-  done
-  sleep 2  # let the co-signer daemons connect + replay sessions
+  start_cosigners $(seq 2 "$THRESH")
   "$CLI" sign --wallet-id "$WID" --message "$SIGN_MSG" --curve "$CURVE" \
     --device-id 1 --keystore "$WORK/ks-1" --password-file "$PW" \
     --signal-server "$SIGNAL" "${ROOM_FLAG[@]}" --timeout "$TIMEOUT" \
     >"$WORK/sign.out" 2>"$WORK/sign.log" || true
+  stop_cosigners
   SIG_HEX="$(field "$WORK/sign.out" signature)"
   MSG_HASH="$(field "$WORK/sign.out" message_hash)"
   [ -z "$SIG_HEX" ] && { c_bad "✗ signing FAILED"; tail -5 "$WORK/sign.log" >&2; exit 1; }
   c_ok "  ✅ signature produced by a ${THRESH}-of-${NODES} quorum"
 fi
 
+RESHARE_GROUP=""
+# --- Phase 3: share refresh / resharing (optional) — holder + retained signers ---
+# Same-set refresh: the wallet holder (node 1) initiates, every other node
+# approves via `serve --auto-approve` (which auto-joins the reshare request).
+# The group key — and therefore the address — must be UNCHANGED afterwards.
+if [ "$RESHARE" = "1" ]; then
+  echo
+  c_dim "▸ resharing — holder + $((NODES - 1)) retained signer(s) refresh every share (address preserved)"
+  start_cosigners $(seq 2 "$NODES")
+  "$CLI" reshare --wallet-id "$WID" --curve "$CURVE" \
+    --device-id 1 --keystore "$WORK/ks-1" --password-file "$PW" \
+    --signal-server "$SIGNAL" "${ROOM_FLAG[@]}" --timeout "$TIMEOUT" \
+    >"$WORK/reshare.out" 2>"$WORK/reshare.log" || true
+  stop_cosigners
+  RESHARE_GROUP="$(field "$WORK/reshare.out" group_public_key)"
+  [ -z "$RESHARE_GROUP" ] && { c_bad "✗ reshare FAILED"; tail -5 "$WORK/reshare.log" >&2; exit 1; }
+  if [ "$RESHARE_GROUP" != "$GROUP" ]; then
+    c_bad "✗ reshare CHANGED the group key ($GROUP → $RESHARE_GROUP) — the address would move!"; exit 1
+  fi
+  c_ok "  ✅ shares refreshed — same group key, address unchanged"
+fi
+
 # --- summary ---
 echo
-if [ -n "$SIG_HEX" ]; then
-  printf '{\n  "ok": true,\n  "nodes": %s,\n  "threshold": %s,\n  "curve": "%s",\n  "wallet_id": "%s",\n  "address": "%s",\n  "group_public_key": "%s",\n  "message_hash": "%s",\n  "signature": "%s"\n}\n' \
-    "$NODES" "$THRESH" "$CURVE" "$WID" "$ADDR" "$GROUP" "$MSG_HASH" "$SIG_HEX"
-else
-  printf '{\n  "ok": true,\n  "nodes": %s,\n  "threshold": %s,\n  "curve": "%s",\n  "wallet_id": "%s",\n  "address": "%s",\n  "group_public_key": "%s"\n}\n' \
-    "$NODES" "$THRESH" "$CURVE" "$WID" "$ADDR" "$GROUP"
-fi
+{
+  printf '{\n  "ok": true,\n  "nodes": %s,\n  "threshold": %s,\n  "curve": "%s",\n' "$NODES" "$THRESH" "$CURVE"
+  printf '  "wallet_id": "%s",\n  "address": "%s",\n  "group_public_key": "%s"' "$WID" "$ADDR" "$GROUP"
+  [ -n "$SIG_HEX" ] && printf ',\n  "message_hash": "%s",\n  "signature": "%s"' "$MSG_HASH" "$SIG_HEX"
+  [ -n "$RESHARE_GROUP" ] && printf ',\n  "reshared": true,\n  "group_key_preserved": true'
+  printf '\n}\n'
+}

--- a/scripts/demo/preflight.sh
+++ b/scripts/demo/preflight.sh
@@ -55,6 +55,13 @@ for spec in "2 2" "2 3"; do
   fi
 done
 
+hdr "2b. Share refresh / recovery (real multi-process reshare)"
+if "$CEREMONY" --nodes 3 --threshold 2 --reshare --timeout 90 >/dev/null 2>&1; then
+  ok "Reshare 2-of-3 — shares refreshed, group key (address) preserved"
+else
+  bad "Reshare 2-of-3 FAILED"
+fi
+
 hdr "3. Live signal server reachability ($SIGNAL)"
 host="$(printf '%s' "$SIGNAL" | sed -E 's#^wss?://##; s#[:/].*$##')"
 REACHABLE=0


### PR DESCRIPTION
## What

Completes the real-process demo driver. After DKG (and optional `--sign`), **`--reshare`** runs the networked same-set share refresh across **real separate processes** — the wallet holder (`reshare`) + the retained signers (`serve --auto-approve`) — and asserts the **group key (and address) is unchanged**.

```
$ scripts/demo/ceremony.sh --nodes 3 --threshold 2 --sign "rotate then verify" --reshare
  ✅ DKG complete — all 3 nodes agree on one group key
  ✅ signature produced by a 2-of-3 quorum
  ✅ shares refreshed — same group key, address unchanged
{ "ok": true, …, "signature": "0x…", "reshared": true, "group_key_preserved": true }
```

Now the recovery/rotation beat has the same one-paste, nothing-hard-coded proof DKG and signing already had.

## How

- Factored co-signer start/stop into `start_cosigners` / `stop_cosigners` so the sign phase (T-1 daemons) and reshare phase (N-1 daemons) **don't overlap on device-ids** — a duplicate id is rejected by the signal server, so phases must tear down before the next starts.
- `preflight.sh`: added a reshare health check (step 2b).
- Docs (investor guide EN/zh, rehearsal checklists EN/zh, user guide): recovery section now offers `ceremony.sh … --reshare` as the self-contained proof.

## Verification (real separate processes, local server)

- DKG + reshare 2-of-3 secp256k1 → group key preserved
- DKG + sign + reshare 2-of-3 ed25519 → signature produced **and** key preserved (confirms per-phase co-signer teardown avoids device-id collisions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)