### PR TITLE
chore: rename frost-mpc-frost-core→frost-mpc-core; slim flake; drop libssl from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: System deps
-        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
+        run: sudo apt-get update && sudo apt-get install -y pkg-config
 
       # This repo is the headless engine + terminal clients. The GUI products
       # (browser extension, Iced desktop in stars-labs/starlab-desktop) live

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,10 +8,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # Rust (all workspace crates)
 cargo build                              # Build all workspace members
 cargo test                               # Run all Rust tests
-cargo test -p frost-mpc-frost-core      # Test specific package
+cargo test -p frost-mpc-core            # Test specific package
 cargo test -p tui-node                   # Test TUI node
 cargo test test_name                     # Run single test by name
-cargo run --example unified_dkg -p frost-mpc-frost-core  # Run example
+cargo run --example unified_dkg -p frost-mpc-core  # Run example
 cargo run --bin frost-mpc-tui -p tui-node                # Run TUI app
 cargo check                              # Fast type check without codegen
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,7 +1624,7 @@ dependencies = [
  "clap",
  "frost-core",
  "frost-ed25519",
- "frost-mpc-frost-core",
+ "frost-mpc-core",
  "frost-secp256k1",
  "futures-util",
  "hex",
@@ -1640,23 +1640,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "frost-mpc-core-wasm"
-version = "0.1.0"
-dependencies = [
- "console_error_panic_hook",
- "frost-ed25519",
- "frost-mpc-frost-core",
- "frost-secp256k1",
- "getrandom 0.2.17",
- "getrandom 0.4.2",
- "hex",
- "rand_core 0.6.4",
- "serde_json",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "frost-mpc-frost-core"
+name = "frost-mpc-core"
 version = "0.1.0"
 dependencies = [
  "aes-gcm",
@@ -1682,6 +1666,22 @@ dependencies = [
  "sha2 0.11.0",
  "sha3 0.11.0",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "frost-mpc-core-wasm"
+version = "0.1.0"
+dependencies = [
+ "console_error_panic_hook",
+ "frost-ed25519",
+ "frost-mpc-core",
+ "frost-secp256k1",
+ "getrandom 0.2.17",
+ "getrandom 0.4.2",
+ "hex",
+ "rand_core 0.6.4",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5658,7 +5658,7 @@ dependencies = [
  "ethers-core",
  "frost-core",
  "frost-ed25519",
- "frost-mpc-frost-core",
+ "frost-mpc-core",
  "frost-secp256k1",
  "futures-util",
  "gethostname",

--- a/apps/cli-node/Cargo.toml
+++ b/apps/cli-node/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 tui-node = { path = "../tui-node" }
-frost-mpc-frost-core = { path = "../../packages/@frost-mpc/frost-core" }
+frost-mpc-core = { path = "../../packages/@frost-mpc/frost-core" }
 webrtc-signal-server = { path = "../signal-server/server" }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/apps/cli-node/src/reshare.rs
+++ b/apps/cli-node/src/reshare.rs
@@ -2,7 +2,7 @@
 //! library function `run_reshare_simulation` and exercised by the cli-node
 //! integration tests (it is no longer a user-facing CLI subcommand). Runs a
 //! DKG, then refreshes the shares for a (possibly reduced) participant set
-//! in-process via `frost_mpc_frost_core::resharing`, and asserts the recovery
+//! in-process via `frost_mpc_core::resharing`, and asserts the recovery
 //! guarantees:
 //!
 //! - the group public key (your address) is **unchanged** by the refresh,
@@ -16,7 +16,7 @@
 //! command in the meantime.
 
 use frost_core::Ciphersuite;
-use frost_mpc_frost_core::resharing;
+use frost_mpc_core::resharing;
 use std::collections::BTreeMap;
 
 #[derive(serde::Serialize)]

--- a/apps/tui-node/Cargo.toml
+++ b/apps/tui-node/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 # Shared FROST library (DKG state machine, keystore encryption, curve helpers).
-frost-mpc-frost-core = { path = "../../packages/@frost-mpc/frost-core" }
+frost-mpc-core = { path = "../../packages/@frost-mpc/frost-core" }
 
 # FROST 2.2 — secp256k1 for Ethereum, ed25519 for Solana, `frost-core`
 # for ciphersuite-generic bounds.

--- a/apps/tui-node/src/keystore/extension_compat.rs
+++ b/apps/tui-node/src/keystore/extension_compat.rs
@@ -85,7 +85,7 @@ pub struct ExtensionWalletMetadata {
 }
 
 // Use shared frost-core library for keystore functionality
-use frost_mpc_frost_core::{
+use frost_mpc_core::{
     keystore::KeystoreData as FrostKeystoreData,
 };
 use frost_secp256k1::keys::{KeyPackage as Secp256k1KeyPackage, PublicKeyPackage as Secp256k1PublicKeyPackage};

--- a/apps/tui-node/src/protocal/reshare.rs
+++ b/apps/tui-node/src/protocal/reshare.rs
@@ -482,7 +482,7 @@ where
 mod tests {
     use super::*;
     use frost_secp256k1::Secp256K1Sha256 as Secp;
-    use frost_mpc_frost_core::resharing;
+    use frost_mpc_core::resharing;
     use std::collections::BTreeMap;
 
     fn id(i: u16) -> Identifier<Secp> {

--- a/flake.nix
+++ b/flake.nix
@@ -47,24 +47,11 @@
             freetype
           ];
 
-          # Linux-specific dependencies (includes Wayland)
-          linuxBuildInputs = with pkgs; [
-            # Wayland dependencies for native node GUI
-            wayland
-            libxkbcommon
-            wayland-protocols
-
-            # Graphics libraries
-            libGL
-            vulkan-loader
-            mesa
-
-            # X11 fallback dependencies
-            xorg.libX11
-            xorg.libXcursor
-            xorg.libXrandr
-            xorg.libXi
-          ];
+          # Linux-specific dependencies. The desktop GUI moved out to
+          # stars-labs/starlab-desktop, so the graphics/windowing libs that
+          # used to live here are gone. Nothing Linux-only remains for the
+          # headless engine + browser-extension/wasm build.
+          linuxBuildInputs = [ ];
 
           # macOS-specific dependencies
           darwinBuildInputs = with pkgs; [
@@ -74,18 +61,7 @@
           ];
 
           # Platform-specific library paths
-          linuxLibraryPath = lib.makeLibraryPath (with pkgs; [
-            wayland
-            libxkbcommon
-            vulkan-loader
-            libGL
-            xorg.libX11
-            xorg.libXcursor
-            xorg.libXrandr
-            xorg.libXi
-            fontconfig
-            freetype
-          ]);
+          linuxLibraryPath = lib.makeLibraryPath (with pkgs; [ ]);
 
           # Determine platform-specific inputs
           platformBuildInputs =
@@ -116,10 +92,9 @@
               echo "Platform: ${system}"
               echo ""
               if [[ "${system}" == *"linux"* ]]; then
-                echo "✅ Linux environment configured with Wayland support"
+                echo "✅ Linux environment configured"
               elif [[ "${system}" == *"darwin"* ]]; then
                 echo "✅ macOS environment configured"
-                echo "Note: Wayland dependencies are not available on macOS"
               fi
               echo ""
               echo "Available commands:"

--- a/packages/@frost-mpc/core-wasm/Cargo.toml
+++ b/packages/@frost-mpc/core-wasm/Cargo.toml
@@ -37,7 +37,7 @@ getrandom_02 = { package = "getrandom", version = "0.2", features = ["js"] }
 hex = "0.4.3"
 
 # Use our shared frost-core library
-frost-mpc-frost-core = { path = "../frost-core" }
+frost-mpc-core = { path = "../frost-core" }
 
 # Still need these for specific types
 frost-secp256k1 = { version = "2.2.0", features = ["serde"] }

--- a/packages/@frost-mpc/core-wasm/src/lib.rs
+++ b/packages/@frost-mpc/core-wasm/src/lib.rs
@@ -1,5 +1,5 @@
 use wasm_bindgen::prelude::*;
-use frost_mpc_frost_core::{
+use frost_mpc_core::{
     FrostCurve, FrostError,
     ed25519::Ed25519Curve,
     secp256k1::Secp256k1Curve,

--- a/packages/@frost-mpc/frost-core/Cargo.toml
+++ b/packages/@frost-mpc/frost-core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "frost-mpc-frost-core"
+name = "frost-mpc-core"
 version = "0.1.0"
 edition = "2024"
 description = "Core FROST implementation for MPC Wallet"

--- a/packages/@frost-mpc/frost-core/examples/unified_dkg.rs
+++ b/packages/@frost-mpc/frost-core/examples/unified_dkg.rs
@@ -8,11 +8,11 @@
 //!
 //! Run with: cargo run --example unified_dkg
 
-use frost_mpc_frost_core::hd_derivation::{ChainCode, derive_child_key};
-use frost_mpc_frost_core::unified_dkg::{UnifiedDkg, UnifiedRound1Package};
-use frost_mpc_frost_core::ed25519::Ed25519Curve;
-use frost_mpc_frost_core::secp256k1::Secp256k1Curve;
-use frost_mpc_frost_core::traits::FrostCurve;
+use frost_mpc_core::hd_derivation::{ChainCode, derive_child_key};
+use frost_mpc_core::unified_dkg::{UnifiedDkg, UnifiedRound1Package};
+use frost_mpc_core::ed25519::Ed25519Curve;
+use frost_mpc_core::secp256k1::Secp256k1Curve;
+use frost_mpc_core::traits::FrostCurve;
 use std::collections::BTreeMap;
 
 fn main() {


### PR DESCRIPTION
Post-rename/post-split cleanups on the engine repo.

- **Crate rename** `frost-mpc-frost-core` → `frost-mpc-core` (drops the redundant double "frost"); updated the dependent crates (cli, tui-node, core-wasm) + all `use frost_mpc_frost_core` paths.
- **Slim `flake.nix`**: removed the graphics/Wayland system libs (wayland, libGL, vulkan-loader, mesa, xorg.*, fontconfig/freetype from the GUI paths) — the desktop GUI moved to starlab-desktop, so the engine repo no longer needs them. Kept rust/bun/pkg-config/wasm tooling.
- **CI**: dropped `libssl-dev` (the WS stack is rustls since #84; no openssl-sys in the tree).

`git grep frost-mpc-frost-core` → none. `cargo build --workspace` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)