### PR TITLE
feat(dkg): unified networked DKG — one wallet, all chains (ETH+BTC+SOL+Sui)

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,56 @@
+# Unified networked DKG — one wallet, all chains (ETH+BTC+SOL+Sui)
+
+**Goal:** the tui-node networked (WebRTC mesh) DKG produces a wallet holding BOTH
+ed25519 + secp256k1 keys from a single root secret, so one wallet shows
+Ethereum/Bitcoin (secp256k1) + Solana/Sui (ed25519). Driven by frost-core's
+`UnifiedDkg` (crypto already implemented; the browser/core-wasm already uses it).
+The desktop (starlab-desktop) consumes the multi-curve wallet and shows all chains.
+
+**Why it's an engine feature:** `protocal/dkg.rs` runs generic single-ciphersuite
+`frost_core::keys::dkg::part1::<C>` — one curve per ceremony. `UnifiedDkg` is
+concrete (ed25519+secp256k1) and isn't wired into the mesh transport.
+
+**Reference:** `packages/@frost-mpc/core-wasm/src/lib.rs` (UnifiedDkg over the
+browser mesh) defines the wire shape we must match for cross-client interop:
+`UnifiedRound1Package { ed25519, secp256k1 }`, `UnifiedRound2Packages`.
+
+---
+
+## Stage 1: keystore + AppState plumbing
+**Goal:** persist + load a "unified" wallet (same `wallet_id` in both
+`device/ed25519/` and `device/secp256k1/`); hold UnifiedDkg state on AppState.
+**Changes:** AppState gets `unified_dkg: Option<UnifiedDkg>` (concrete, not `C`).
+Keystore helper `save_unified_wallet(wallet_id, ed_keypkg, secp_keypkg, …)` that
+writes two `WalletMetadata` under one id (storage already supports per-curve dirs).
+**Test:** keystore round-trip — save a unified wallet, reload, both curves present
+with matching group keys.
+**Status:** Not Started
+
+## Stage 2: networked UnifiedDkg driver
+**Goal:** `protocal/unified_dkg_net.rs` mirroring `protocal/dkg.rs`:
+trigger_round1 (`UnifiedDkg::generate_round1` → broadcast `UnifiedRound1Package`),
+process_round1, trigger_round2, process_round2, finalize → both key packages →
+`save_unified_wallet`.
+**Test:** in-process 2-of-2 (simulate-style) — both nodes agree on both curves'
+group keys; persisted wallet has ed25519+secp256k1.
+**Status:** Not Started
+
+## Stage 3: wire protocol + create flow
+**Goal:** data-channel messages for the unified rounds (match core-wasm shape);
+`HeadlessCreateWallet` drives the unified path (a `unified` mode flag, default for
+new wallets). CLI `wallet create` + `session join` do unified.
+**Test:** cross-process (ceremony.sh-style) unified DKG over a local signal server
+→ wallet with ETH+BTC+SOL+Sui addresses; all nodes agree.
+**Status:** Not Started
+
+## Stage 4: desktop UI — show all chains
+**Goal:** starlab-desktop groups wallet entries by `wallet_id` and renders every
+chain address (ETH, BTC, Solana, Sui) per wallet; Create uses the unified path.
+**Test:** launch desktop, run a unified DKG, screenshot showing one wallet with
+all four chains.
+**Status:** Not Started
+
+## Stage 5 (optional): cross-client interop + cleanup
+**Goal:** desktop ↔ browser ↔ CLI run a unified DKG together (wire-shape parity);
+update CLAUDE.md/docs; remove this plan file.
+**Status:** Not Started

--- a/apps/cli-node/src/main.rs
+++ b/apps/cli-node/src/main.rs
@@ -81,10 +81,11 @@ struct OneShot {
     room: Option<String>,
     #[arg(long, default_value_t = 90)]
     timeout: u64,
-    /// Ciphersuite: secp256k1 (default; Ethereum/Bitcoin) or ed25519 (Solana).
+    /// Ciphersuite: secp256k1 (default; Ethereum/Bitcoin), ed25519 (Solana), or
+    /// "unified" (BOTH curves from one DKG → Ethereum + Solana in one wallet).
     /// ed25519 yields a standard RFC-8032 signature that ANY off-the-shelf
-    /// verifier (and Solana) can check — ideal for an independently-checkable
-    /// demo. All participants of one ceremony must use the same curve.
+    /// verifier (and Solana) can check. All participants of one ceremony must
+    /// use the same curve.
     #[arg(long, default_value = "secp256k1")]
     curve: String,
     #[arg(long, default_value = "")]

--- a/apps/cli-node/src/oneshot.rs
+++ b/apps/cli-node/src/oneshot.rs
@@ -82,6 +82,9 @@ fn start(
             let _ = ev_tx.send(e);
         }
     };
+    // "unified" runs the dual-curve ceremony — spawn on secp256k1 (the generic
+    // `C` DKG fields are unused on the unified path; the UnifiedDkg lives in
+    // app_state.unified_dkg) and flip the model into unified mode below.
     let tx = if opts.curve == "ed25519" {
         spawn_ed25519(
             opts.device_id.clone(),
@@ -97,6 +100,9 @@ fn start(
             cb,
         )
     };
+    if opts.curve == "unified" {
+        let _ = tx.send(Message::SetUnifiedMode { unified: true });
+    }
     (tx, ev_rx, roster)
 }
 

--- a/apps/tui-node/src/elm/command.rs
+++ b/apps/tui-node/src/elm/command.rs
@@ -43,7 +43,7 @@ pub enum Command {
     /// AnnounceSession over the signaling WebSocket. Does NOT trigger the
     /// FROST cryptographic protocol — that waits for `StartFrostProtocol`
     /// once the WebRTC mesh is actually established.
-    StartDKG { config: WalletConfig },
+    StartDKG { config: WalletConfig, unified: bool },
     /// Everyone (creator + joiners): the WebRTC mesh is up and data channels
     /// are reachable; run FROST Round 1 against the participants captured in
     /// `AppState::session`. No session announcement happens here, which is
@@ -51,6 +51,19 @@ pub enum Command {
     /// caused joiners to re-announce the session under their own `proposer_id`,
     /// clobbering the creator's record server-side.
     StartFrostProtocol,
+    /// Stash the unified-DKG finalize context (password / keystore path / label)
+    /// onto AppState before the unified ceremony runs, so the round-2 completion
+    /// can persist both curves without re-threading these through every message.
+    /// Batched ahead of `StartFrostProtocol` on the mesh-ready edge.
+    PrepareUnifiedFinalize {
+        password: String,
+        keystore_path: String,
+        label: Option<String>,
+    },
+    /// Process a peer's UNIFIED round-1 package received over a data channel.
+    ProcessUnifiedDKGRound1 { from_device: String, package_json: String },
+    /// Process a peer's UNIFIED round-2 message received over a data channel.
+    ProcessUnifiedDKGRound2 { from_device: String, message_json: String },
     /// Process a peer's Round 1 package received over a data channel.
     /// Calls `protocal::dkg::process_dkg_round1` which stores the package and
     /// auto-triggers Round 2 once all `session.total` packages have arrived.
@@ -261,6 +274,154 @@ pub(crate) fn decode_keystore_blob<C: frost_core::Ciphersuite>(
     // field would still decode up to this point. For today, there should
     // be no trailing bytes.
     Ok((kp, pkp))
+}
+
+/// Wire prefix for a unified round-1 package (mirrors `DKG_ROUND1:`). The
+/// payload after the colon is the `UnifiedRound1Package` JSON.
+pub(crate) const UNIFIED_DKG_ROUND1_PREFIX: &str = "UNIFIED_DKG_ROUND1:";
+/// Wire prefix for a unified round-2 message (`UnifiedRound2Message` JSON).
+pub(crate) const UNIFIED_DKG_ROUND2_PREFIX: &str = "UNIFIED_DKG_ROUND2:";
+
+/// Broadcast our unified round-1 package to every other session participant.
+/// Same transport as the single-curve `DKG_ROUND1:` broadcast (a
+/// `WebRTCMessage::SimpleMessage` with a prefix), just a different prefix and a
+/// JSON (not base64) payload.
+async fn broadcast_unified_round1<C>(
+    app_state: std::sync::Arc<tokio::sync::Mutex<crate::utils::appstate_compat::AppState<C>>>,
+    self_device_id: &str,
+    pkg: &crate::protocal::unified_dkg::UnifiedRound1Package,
+) where
+    C: frost_core::Ciphersuite + Send + Sync + 'static,
+{
+    let participants = {
+        let state = app_state.lock().await;
+        state
+            .session
+            .as_ref()
+            .map(|s| s.participants.clone())
+            .unwrap_or_default()
+    };
+    let json = match serde_json::to_string(pkg) {
+        Ok(j) => j,
+        Err(e) => {
+            error!("unified round1 serialize failed: {}", e);
+            return;
+        }
+    };
+    let message = crate::protocal::signal::WebRTCMessage::<C>::SimpleMessage {
+        text: format!("{}{}", UNIFIED_DKG_ROUND1_PREFIX, json),
+    };
+    // Give data channels a moment to settle (mirrors the single-curve path).
+    tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+    for device_id in participants {
+        if device_id == self_device_id {
+            continue;
+        }
+        for attempt in 0..10u32 {
+            match crate::utils::device::send_webrtc_message(&device_id, &message, app_state.clone())
+                .await
+            {
+                Ok(()) => {
+                    info!("✅ sent unified round1 to {}", device_id);
+                    break;
+                }
+                Err(e) if attempt < 9 => {
+                    info!("⏳ unified round1 to {} not ready ({}); retrying", device_id, e);
+                    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                }
+                Err(e) => warn!("❌ unified round1 to {} failed: {}", device_id, e),
+            }
+        }
+    }
+}
+
+/// Send our unified round-2 message (per-recipient packages) to every peer. The
+/// message carries the full recipient map; each peer picks out its own entry
+/// (matches `UnifiedDkg::add_round2_package`'s 1-based index contract).
+async fn send_unified_round2<C>(
+    app_state: std::sync::Arc<tokio::sync::Mutex<crate::utils::appstate_compat::AppState<C>>>,
+    self_device_id: &str,
+    msg: &crate::protocal::unified_dkg::UnifiedRound2Message,
+) where
+    C: frost_core::Ciphersuite + Send + Sync + 'static,
+{
+    let participants = {
+        let state = app_state.lock().await;
+        state
+            .session
+            .as_ref()
+            .map(|s| s.participants.clone())
+            .unwrap_or_default()
+    };
+    let json = match serde_json::to_string(msg) {
+        Ok(j) => j,
+        Err(e) => {
+            error!("unified round2 serialize failed: {}", e);
+            return;
+        }
+    };
+    let message = crate::protocal::signal::WebRTCMessage::<C>::SimpleMessage {
+        text: format!("{}{}", UNIFIED_DKG_ROUND2_PREFIX, json),
+    };
+    for device_id in participants {
+        if device_id == self_device_id {
+            continue;
+        }
+        match crate::utils::device::send_webrtc_message(&device_id, &message, app_state.clone())
+            .await
+        {
+            Ok(()) => info!("✅ sent unified round2 to {}", device_id),
+            Err(e) => warn!("❌ unified round2 to {} failed: {}", device_id, e),
+        }
+    }
+}
+
+/// Finalize the unified ceremony: persist both curves and emit `DKGFinalized`
+/// (which the CLI bridge surfaces as `dkg_complete`). Idempotent — `finalize`
+/// returns `None` once the wallet is already written, so calling this from
+/// multiple completion edges is safe.
+async fn try_finalize_unified<C>(
+    app_state: &std::sync::Arc<tokio::sync::Mutex<crate::utils::appstate_compat::AppState<C>>>,
+    tx: &tokio::sync::mpsc::UnboundedSender<Message>,
+) where
+    C: frost_core::Ciphersuite + Send + Sync + 'static,
+{
+    let (password, keystore_path, label) = {
+        let state = app_state.lock().await;
+        state.unified_finalize.clone().unwrap_or_default()
+    };
+    let wallet_id = {
+        let state = app_state.lock().await;
+        state
+            .session
+            .as_ref()
+            .map(|s| crate::protocal::dkg::wallet_id_from_session(&s.session_id))
+            .unwrap_or_else(|| "wallet".to_string())
+    };
+    if let Some(outcome) = crate::protocal::unified_dkg::finalize(
+        app_state.clone(),
+        wallet_id,
+        password,
+        keystore_path,
+        label,
+    )
+    .await
+    {
+        // Both curves' canonical addresses, surfaced to the UI/CLI.
+        let addresses = vec![
+            ("ethereum".to_string(), outcome.eth_address.clone()),
+            ("solana".to_string(), outcome.solana_address.clone()),
+        ];
+        let _ = tx.send(Message::DKGFinalized {
+            wallet_id: outcome.wallet_id,
+            // The bridge derives the primary address from this + curve_type;
+            // here we pass the secp256k1 group key (Ethereum). The unified
+            // wallet's Solana address rides in `addresses`.
+            group_pubkey_hex: outcome.secp256k1_group_public_key,
+            curve_type: "secp256k1".to_string(),
+            addresses,
+        });
+    }
 }
 
 /// Load an existing wallet's OLD share + metadata from the keystore and seed the
@@ -555,7 +716,7 @@ impl Command {
                 }
             }
             
-            Command::StartDKG { config } => {
+            Command::StartDKG { config, unified } => {
                 // Creator-only path. Responsibility: mint a session_id, store
                 // it in AppState, broadcast AnnounceSession so joiners can
                 // discover us. FROST Round 1 is NOT triggered here — it needs
@@ -668,10 +829,18 @@ impl Command {
                     // Announce the session through the shared channel.
                     // `curve_type` comes from the ciphersuite type witness
                     // via `CurveIdentifier`, so joiners learn the real curve
-                    // from the announce rather than the legacy "unified"
-                    // placeholder.
-                    let announced_curve =
-                        <C as crate::utils::curve_traits::CurveIdentifier>::curve_type();
+                    // from the announce. UNIFIED ceremonies announce the
+                    // "unified" marker instead, so every node runs the dual-curve
+                    // path (creator + joiners agree off this one string).
+                    let announced_curve: &str = if unified {
+                        "unified"
+                    } else {
+                        <C as crate::utils::curve_traits::CurveIdentifier>::curve_type()
+                    };
+                    if unified {
+                        let mut state = app_state.lock().await;
+                        state.unified_mode = true;
+                    }
                     let session_info = serde_json::json!({
                         "session_id": session_id.clone(),
                         "total": config_clone.total_participants,
@@ -870,7 +1039,7 @@ impl Command {
                 // twice would regenerate the secret/package and break the
                 // protocol mid-flight. We atomically transition dkg_state to
                 // `Round1InProgress` only from `Idle` — subsequent calls bail.
-                let (device_id, internal_cmd_tx, have_session, already_running, is_reshare, dkg_in_progress) = {
+                let (device_id, internal_cmd_tx, have_session, already_running, is_reshare, dkg_in_progress, is_unified) = {
                     let mut state_guard = app_state.lock().await;
                     let already = !matches!(state_guard.dkg_state, crate::utils::state::DkgState::Idle);
                     if !already {
@@ -883,6 +1052,7 @@ impl Command {
                         already,
                         state_guard.reshare_in_progress,
                         state_guard.dkg_in_progress,
+                        state_guard.unified_mode,
                     )
                 };
                 if already_running {
@@ -943,13 +1113,35 @@ impl Command {
                     return Ok(());
                 }
 
+                // UNIFIED fork: run the dual-curve ceremony (ed25519 + secp256k1)
+                // instead of the single-curve path. Generates one round-1 package
+                // for both curves and broadcasts it to every peer.
+                if is_unified {
+                    info!(
+                        "🌐 Triggering UNIFIED FROST DKG Round 1 for device_id={}",
+                        device_id
+                    );
+                    if let Some(pkg) = crate::protocal::unified_dkg::start_round1(
+                        app_state.clone(),
+                        device_id.clone(),
+                    )
+                    .await
+                    {
+                        broadcast_unified_round1(app_state.clone(), &device_id, &pkg).await;
+                        let _ = tx.send(Message::Info {
+                            message: "✅ Unified DKG Round 1 initiated (ed25519 + secp256k1)".into(),
+                        });
+                    }
+                    return Ok(());
+                }
+
                 let internal_tx = internal_cmd_tx.unwrap_or_else(|| {
                     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
                     tx
                 });
 
                 info!(
-                    "🌐 Triggering unified FROST DKG Round 1 for device_id={}",
+                    "🌐 Triggering single-curve FROST DKG Round 1 for device_id={}",
                     device_id
                 );
                 crate::protocal::dkg::handle_trigger_dkg_round1(
@@ -963,6 +1155,60 @@ impl Command {
                 let _ = tx.send(Message::Info {
                     message: "✅ DKG Round 1 initiated - exchanging commitments...".to_string(),
                 });
+            }
+
+            Command::PrepareUnifiedFinalize { password, keystore_path, label } => {
+                let mut state = app_state.lock().await;
+                state.unified_finalize = Some((password, keystore_path, label));
+            }
+
+            Command::ProcessUnifiedDKGRound1 { from_device, package_json } => {
+                let pkg: crate::protocal::unified_dkg::UnifiedRound1Package =
+                    match serde_json::from_str(&package_json) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            error!("Bad unified round1 JSON from {}: {}", from_device, e);
+                            return Ok(());
+                        }
+                    };
+                let ready = crate::protocal::unified_dkg::ingest_round1(
+                    app_state.clone(),
+                    from_device,
+                    pkg,
+                )
+                .await;
+                if ready {
+                    // Run part2 + send targeted round-2 packages to every peer.
+                    if let Some(round2) =
+                        crate::protocal::unified_dkg::start_round2(app_state.clone()).await
+                    {
+                        let device_id = app_state.lock().await.device_id.clone();
+                        send_unified_round2(app_state.clone(), &device_id, &round2).await;
+                    }
+                    // Race fix (mirrors single-curve re-feed): a peer's round-2
+                    // package can arrive BEFORE our part2 ran, so it was ingested
+                    // (can_finalize=false then). Now that our part2 is done,
+                    // re-check and finalize if everything's present.
+                    if crate::protocal::unified_dkg::can_finalize(app_state.clone()).await {
+                        try_finalize_unified(app_state, &tx).await;
+                    }
+                }
+            }
+
+            Command::ProcessUnifiedDKGRound2 { from_device, message_json } => {
+                let msg: crate::protocal::unified_dkg::UnifiedRound2Message =
+                    match serde_json::from_str(&message_json) {
+                        Ok(m) => m,
+                        Err(e) => {
+                            error!("Bad unified round2 JSON from {}: {}", from_device, e);
+                            return Ok(());
+                        }
+                    };
+                let ready =
+                    crate::protocal::unified_dkg::ingest_round2(app_state.clone(), msg).await;
+                if ready {
+                    try_finalize_unified(app_state, &tx).await;
+                }
             }
 
             Command::ProcessDKGRound1 {
@@ -1321,6 +1567,11 @@ impl Command {
                             .unwrap_or_else(|| "Ed25519".to_string())
                     };
                     info!("📊 Joining session with curve type: {}, total {}", curve_type, known_total);
+                    // A "unified" announce means the dual-curve ceremony — flip
+                    // the joiner into unified mode so mesh-ready runs that path.
+                    if curve_type == "unified" {
+                        state.unified_mode = true;
+                    }
                     state.session = Some(crate::protocal::signal::SessionInfo {
                         session_id: session_id.clone(),
                         proposer_id: if known_proposer.is_empty() {
@@ -2678,7 +2929,8 @@ mod tests {
                 total_participants: 3,
                 threshold: 2,
                 mode: crate::elm::model::WalletMode::Online,
-            }
+            },
+            unified: false,
         };
         assert!(matches!(cmd, Command::StartDKG { .. }));
     }

--- a/apps/tui-node/src/elm/message.rs
+++ b/apps/tui-node/src/elm/message.rs
@@ -68,6 +68,11 @@ pub enum Message {
     /// extension does automatically. Replies stream back as
     /// `SessionDiscovered`.
     HeadlessRefreshSessions,
+    /// Mark this node as a UNIFIED-DKG creator (CLI `--curve unified`). Sets
+    /// `model.wallet_state.unified` so the subsequent `HeadlessCreateWallet`
+    /// announces `curve_type: "unified"` and runs the unified ceremony. Joiners
+    /// don't need this — they learn "unified" from the announce.
+    SetUnifiedMode { unified: bool },
 
     // Wallet management messages
     CreateWallet { config: WalletConfig },
@@ -150,6 +155,10 @@ pub enum Message {
     ProcessDKGRound2 { from_device: String, package_bytes: Vec<u8> },  // Process received DKG Round 2 package
     ProcessReshareRound1 { from_device: String, package_bytes: Vec<u8> }, // Reshare round 1 from a peer (#45)
     ProcessReshareRound2 { from_device: String, package_bytes: Vec<u8> }, // Reshare round 2 from a peer (#45)
+    /// Unified-DKG round 1 from a peer (JSON `UnifiedRound1Package`).
+    ProcessUnifiedDKGRound1 { from_device: String, package_json: String },
+    /// Unified-DKG round 2 from a peer (JSON `UnifiedRound2Message`).
+    ProcessUnifiedDKGRound2 { from_device: String, message_json: String },
     DKGKeyGenerated { group_pubkey_hex: String },                      // Final FROST key ready
     /// Fires after `Command::UnlockWallet` successfully decrypted the
     /// wallet file and stashed `KeyPackage` + `PublicKeyPackage` on

--- a/apps/tui-node/src/elm/model.rs
+++ b/apps/tui-node/src/elm/model.rs
@@ -176,6 +176,12 @@ pub struct WalletState {
     /// from here instead — keeps session announcements honest about
     /// what curve is actually running.
     pub curve_type: &'static str,
+    /// `true` when this node runs a UNIFIED ceremony (ed25519 + secp256k1 from
+    /// one DKG). Set on the creator from `Message::SetUnifiedMode` (CLI
+    /// `--curve unified`); the announce then carries `curve_type: "unified"`
+    /// and joiners learn it from the announce. Independent of `curve_type`
+    /// (which stays the runner's concrete curve).
+    pub unified: bool,
     /// Live draft of the message the user is typing on the
     /// `SignTransaction` screen. Cleared on submit and on every exit
     /// from the screen (same discipline as `password_draft`).

--- a/apps/tui-node/src/elm/update.rs
+++ b/apps/tui-node/src/elm/update.rs
@@ -29,6 +29,30 @@ fn enter_round1(model: &mut Model) {
     }
 }
 
+/// Build the mesh-ready FROST-trigger batch. For a unified ceremony, prepend a
+/// `PrepareUnifiedFinalize` that captures the password/keystore/label so the
+/// round-2 completion can persist both curves. The password is taken (cleared)
+/// from the model — it lives only on the in-flight command afterwards.
+fn frost_trigger_batch(model: &mut Model) -> Command {
+    let mut cmds = Vec::new();
+    if model.wallet_state.unified {
+        if let Some(password) = model.wallet_state.pending_password.take() {
+            let label = {
+                let s = model.wallet_state.wallet_name_draft.trim().to_string();
+                if s.is_empty() { None } else { Some(s) }
+            };
+            cmds.push(Command::PrepareUnifiedFinalize {
+                password,
+                keystore_path: model.wallet_state.keystore_path.clone(),
+                label,
+            });
+        }
+    }
+    cmds.push(Command::StartFrostProtocol);
+    cmds.push(Command::SendMessage(Message::ForceRemount));
+    Command::Batch(cmds)
+}
+
 /// The main update function that handles all state transitions
 pub fn update(model: &mut Model, msg: Message) -> Option<Command> {
     debug!("Processing message: {:?}", msg);
@@ -341,6 +365,12 @@ pub fn update(model: &mut Model, msg: Message) -> Option<Command> {
         // Headless creator entry: seed the same state ThresholdConfig +
         // PasswordPrompt would have set, then hand off to SubmitPassword's
         // creator branch (which builds the config + announces the session).
+        Message::SetUnifiedMode { unified } => {
+            info!("Unified DKG mode set to {}", unified);
+            model.wallet_state.unified = unified;
+            None
+        }
+
         Message::HeadlessCreateWallet { config, password, label } => {
             model.wallet_state.creating_wallet =
                 Some(crate::elm::model::CreateWalletState {
@@ -691,8 +721,14 @@ pub fn update(model: &mut Model, msg: Message) -> Option<Command> {
             info!("Added current device as participant: {}", model.device_id);
             
             // Create active session with placeholder session ID.
-            // `curve_type` comes from the Model's boot-time snapshot of
-            // `C::curve_type()` — no more "unified" placeholder.
+            // `curve_type` is the Model's boot-time snapshot of `C::curve_type()`,
+            // UNLESS this is a unified ceremony — then it's the "unified" marker
+            // that every node branches on (creator + joiners).
+            let creator_curve = if model.wallet_state.unified {
+                "unified".to_string()
+            } else {
+                model.wallet_state.curve_type.to_string()
+            };
             model.active_session = Some(SessionInfo {
                 session_id: temp_session_id.clone(),
                 proposer_id: model.device_id.clone(),
@@ -700,7 +736,7 @@ pub fn update(model: &mut Model, msg: Message) -> Option<Command> {
                 threshold: config.threshold,
                 participants,
                 session_type: SessionType::DKG,
-                curve_type: model.wallet_state.curve_type.to_string(),
+                curve_type: creator_curve,
                 coordination_type: "online".to_string(),
                 signing_message_hex: None,
             });
@@ -716,7 +752,7 @@ pub fn update(model: &mut Model, msg: Message) -> Option<Command> {
             model.pending_operations.push(Operation::CreateWallet(config.clone()));
             
             // Start DKG process - this will generate the real session ID
-            Some(Command::StartDKG { config })
+            Some(Command::StartDKG { config, unified: model.wallet_state.unified })
         }
         
         Message::SelectWallet { wallet_id } => {
@@ -1489,10 +1525,7 @@ pub fn update(model: &mut Model, msg: Message) -> Option<Command> {
             // via the DkgState::Idle → Round1InProgress guard.
             info!("🚀 StartDKGProtocol — mesh ready, dispatching FROST Round 1 trigger");
             enter_round1(model);
-            Some(Command::Batch(vec![
-                Command::StartFrostProtocol,
-                Command::SendMessage(Message::ForceRemount),
-            ]))
+            Some(frost_trigger_batch(model))
         }
 
         Message::InitiateDKG { params } => {
@@ -1505,10 +1538,7 @@ pub fn update(model: &mut Model, msg: Message) -> Option<Command> {
             // server-side. We only want the FROST trigger here.
             info!("Mesh is ready — dispatching FROST Round 1 trigger. params={:?}", params);
             enter_round1(model);
-            Some(Command::Batch(vec![
-                Command::StartFrostProtocol,
-                Command::SendMessage(Message::ForceRemount),
-            ]))
+            Some(frost_trigger_batch(model))
         }
         
         Message::ProcessDKGRound1 { from_device, package_bytes } => {
@@ -1528,6 +1558,12 @@ pub fn update(model: &mut Model, msg: Message) -> Option<Command> {
         }
         Message::ProcessReshareRound2 { from_device, package_bytes } => {
             Some(Command::ProcessReshareRound2 { from_device, package_bytes })
+        }
+        Message::ProcessUnifiedDKGRound1 { from_device, package_json } => {
+            Some(Command::ProcessUnifiedDKGRound1 { from_device, package_json })
+        }
+        Message::ProcessUnifiedDKGRound2 { from_device, message_json } => {
+            Some(Command::ProcessUnifiedDKGRound2 { from_device, message_json })
         }
         Message::HeadlessReshare { wallet_id, password, keystore_path } => {
             Some(Command::StartReshare { wallet_id, password, keystore_path })

--- a/apps/tui-node/src/keystore/storage.rs
+++ b/apps/tui-node/src/keystore/storage.rs
@@ -179,6 +179,57 @@ impl Keystore {
         Ok(wallet_id)
     }
 
+    /// Persist a UNIFIED wallet: the SAME `wallet_id` under BOTH `ed25519/` and
+    /// `secp256k1/` curve dirs, from one dual-curve DKG ceremony. Unlike
+    /// `create_wallet_multi_chain` (which rejects a duplicate wallet_id), this
+    /// deliberately writes two curve-scoped files sharing the id — they live in
+    /// different curve directories and never collide on disk. The wallet thus
+    /// yields Ethereum/Bitcoin (secp256k1) AND Solana/Sui (ed25519) addresses.
+    #[allow(clippy::too_many_arguments)]
+    pub fn create_wallet_unified(
+        &mut self,
+        wallet_id: &str,
+        threshold: u16,
+        total_participants: u16,
+        participant_index: u16,
+        participants: Vec<String>,
+        label: Option<String>,
+        password: &str,
+        // (curve, group_public_key_hex, key_share_blob) for each curve.
+        ed25519_group_public_key: &str,
+        ed25519_key_share: &[u8],
+        secp256k1_group_public_key: &str,
+        secp256k1_key_share: &[u8],
+    ) -> Result<String> {
+        let wallet_id = wallet_id.replace(['/', '\\', ':'], "-");
+
+        for (curve, group_pk, share) in [
+            ("ed25519", ed25519_group_public_key, ed25519_key_share),
+            ("secp256k1", secp256k1_group_public_key, secp256k1_key_share),
+        ] {
+            let mut metadata = WalletMetadata::with_participants(
+                wallet_id.clone(),
+                self.device_id.clone(),
+                curve.to_string(),
+                threshold,
+                total_participants,
+                participant_index,
+                group_pk.to_string(),
+                participants.clone(),
+            );
+            metadata.label = label
+                .clone()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty());
+
+            // Atomic write — never leaves a curve dir with a half-written share.
+            self.save_wallet_file_atomic(&wallet_id, share, password, &metadata)?;
+            self.wallet_cache.push(metadata);
+        }
+
+        Ok(wallet_id)
+    }
+
     /// Overwrite an existing wallet's key share + the refresh-affected metadata
     /// (threshold / total / participants / participant_index) **in place** for a
     /// reshare (#45): same `wallet_id`, same `curve_type`, same

--- a/apps/tui-node/src/network/webrtc.rs
+++ b/apps/tui-node/src/network/webrtc.rs
@@ -83,6 +83,33 @@ pub async fn dispatch_data_channel_msg<C>(
     if webrtc_tag == Some("SimpleMessage")
         && let Some(msg_text) = json_msg.get("text").and_then(|v| v.as_str()) {
             use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+            // Unified-DKG frames (ed25519 + secp256k1 in one ceremony). Same
+            // SimpleMessage transport as the single-curve DKG rounds, but the
+            // payload is JSON (not base64) and routes to the unified driver.
+            if let Some(package_json) =
+                msg_text.strip_prefix(crate::elm::command::UNIFIED_DKG_ROUND1_PREFIX)
+            {
+                info!("🔑 Received UNIFIED DKG Round 1 from {}", device_id_recv);
+                if let Some(tx) = &ui_msg_tx {
+                    let _ = tx.send(crate::elm::message::Message::ProcessUnifiedDKGRound1 {
+                        from_device: device_id_recv.clone(),
+                        package_json: package_json.to_string(),
+                    });
+                }
+                return;
+            }
+            if let Some(message_json) =
+                msg_text.strip_prefix(crate::elm::command::UNIFIED_DKG_ROUND2_PREFIX)
+            {
+                info!("🔐 Received UNIFIED DKG Round 2 from {}", device_id_recv);
+                if let Some(tx) = &ui_msg_tx {
+                    let _ = tx.send(crate::elm::message::Message::ProcessUnifiedDKGRound2 {
+                        from_device: device_id_recv.clone(),
+                        message_json: message_json.to_string(),
+                    });
+                }
+                return;
+            }
             if let Some(package_data) = msg_text.strip_prefix("DKG_ROUND1:") {
                 info!("🔑 Received DKG Round 1 package from {}", device_id_recv);
                 match BASE64.decode(package_data) {

--- a/apps/tui-node/src/protocal/mod.rs
+++ b/apps/tui-node/src/protocal/mod.rs
@@ -4,3 +4,4 @@ pub mod reshare;
 pub mod signal;
 pub mod session_types;
 pub mod signing;
+pub mod unified_dkg;

--- a/apps/tui-node/src/protocal/unified_dkg.rs
+++ b/apps/tui-node/src/protocal/unified_dkg.rs
@@ -1,0 +1,409 @@
+//! Transport-agnostic driver for the **unified** networked DKG.
+//!
+//! Wraps [`frost_mpc_core::unified_dkg::UnifiedDkg`] (which runs FROST DKG for
+//! ed25519 + secp256k1 simultaneously from one root secret per participant) and
+//! adapts it to the WebRTC mesh used by the rest of the app. It mirrors the
+//! single-curve driver in [`crate::protocal::dkg`] but produces a wallet with
+//! BOTH curves (→ Ethereum/Bitcoin AND Solana/Sui addresses).
+//!
+//! The driver is intentionally thin: it owns no networking. The caller
+//! (command/dispatch layer) is responsible for serializing the round messages
+//! over data channels and routing incoming ones back in. The driver exposes:
+//!
+//! - [`start_round1`]    — create + init the `UnifiedDkg`, return our round-1 pkg
+//! - [`ingest_round1`]   — fold in a peer's round-1 pkg; true ⇒ ready for round 2
+//! - [`start_round2`]    — run part2, return the per-recipient round-2 packages
+//! - [`ingest_round2`]   — fold in a peer's round-2 pkg; true ⇒ ready to finalize
+//! - [`finalize`]        — run part3 for both curves and persist the wallet
+//!
+//! The `UnifiedDkg` is concrete (not generic over `C`); it lives in the
+//! `app_state.unified_dkg` field. The Elm app's generic `C` DKG fields are
+//! ignored on this path.
+
+use crate::utils::appstate_compat::AppState;
+use frost_core::Ciphersuite;
+use frost_mpc_core::unified_dkg::{UnifiedDkg, UnifiedRound2Packages};
+// Re-export the core round-1 package so callers (command layer, dispatch) can
+// name it through this driver module — single import surface for the unified path.
+pub use frost_mpc_core::unified_dkg::UnifiedRound1Package;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tracing::{error, info, warn};
+
+/// One participant's round-2 packages, addressed to their recipients.
+///
+/// Round 2 in FROST is targeted: participant A produces a distinct package for
+/// each other participant. We serialize the whole per-recipient map once and let
+/// each receiver pick out the entry keyed by *their* 1-based participant index.
+/// (Simpler over the mesh than crafting N separate frames, and tiny.)
+#[derive(Serialize, Deserialize)]
+pub struct UnifiedRound2Message {
+    /// 1-based participant index of the sender (canonical-sorted order).
+    pub from_index: u16,
+    /// ed25519: recipient_index → hex-encoded round-2 package.
+    pub ed25519: std::collections::BTreeMap<u16, String>,
+    /// secp256k1: recipient_index → hex-encoded round-2 package.
+    pub secp256k1: std::collections::BTreeMap<u16, String>,
+}
+
+/// Result of a finished unified ceremony — both group keys + canonical addresses.
+pub struct UnifiedDkgOutcome {
+    pub wallet_id: String,
+    pub ed25519_group_public_key: String,
+    pub secp256k1_group_public_key: String,
+    pub solana_address: String,
+    pub eth_address: String,
+}
+
+/// Canonical 1-based participant index for `device_id`, over the SORTED
+/// participant list — identical on every node (matches `dkg::canonical_identifier`).
+pub fn canonical_index(participants: &[String], device_id: &str) -> Option<u16> {
+    let mut sorted: Vec<&String> = participants.iter().collect();
+    sorted.sort();
+    let idx = sorted.iter().position(|p| p.as_str() == device_id)?;
+    u16::try_from(idx).ok()?.checked_add(1)
+}
+
+/// Create a fresh `UnifiedDkg`, init it with this node's canonical index + the
+/// session params, and produce our round-1 package (for both curves).
+///
+/// Returns the round-1 package JSON to broadcast, or `None` on a protocol-level
+/// error (already logged + reflected onto `dkg_state`).
+pub async fn start_round1<C>(
+    state: Arc<Mutex<AppState<C>>>,
+    self_device_id: String,
+) -> Option<UnifiedRound1Package>
+where
+    C: Ciphersuite + Send + Sync + 'static,
+{
+    let mut guard = state.lock().await;
+
+    let session = match &guard.session {
+        Some(s) => s.clone(),
+        None => {
+            error!("unified DKG: no session available for round 1");
+            guard.dkg_state = crate::utils::state::DkgState::Failed("No session".into());
+            return None;
+        }
+    };
+
+    let my_index = match canonical_index(&session.participants, &self_device_id) {
+        Some(i) => i,
+        None => {
+            error!(
+                "unified DKG: self_device_id {} not in participants {:?}",
+                self_device_id, session.participants
+            );
+            guard.dkg_state =
+                crate::utils::state::DkgState::Failed("self not in participants".into());
+            return None;
+        }
+    };
+
+    let mut dkg = UnifiedDkg::new();
+    dkg.init_dkg(my_index, session.total, session.threshold);
+
+    let round1 = match dkg.generate_round1() {
+        Ok(pkg) => pkg,
+        Err(e) => {
+            error!("unified DKG: generate_round1 failed: {}", e);
+            guard.dkg_state =
+                crate::utils::state::DkgState::Failed(format!("unified round1: {e}"));
+            return None;
+        }
+    };
+
+    guard.dkg_state = crate::utils::state::DkgState::Round1InProgress;
+    guard.unified_dkg = Some(dkg);
+    info!(
+        "unified DKG: round 1 generated for {} (index {}/{}, threshold {})",
+        self_device_id, my_index, session.total, session.threshold
+    );
+    Some(round1)
+}
+
+/// Fold in a peer's round-1 package. Returns `true` when all peers' round-1
+/// packages have arrived (ready to run round 2).
+pub async fn ingest_round1<C>(
+    state: Arc<Mutex<AppState<C>>>,
+    from_device_id: String,
+    package: UnifiedRound1Package,
+) -> bool
+where
+    C: Ciphersuite + Send + Sync + 'static,
+{
+    let mut guard = state.lock().await;
+
+    let session = match &guard.session {
+        Some(s) => s.clone(),
+        None => return false,
+    };
+    let from_index = match canonical_index(&session.participants, &from_device_id) {
+        Some(i) => i,
+        None => {
+            error!("unified DKG: round1 from unknown device {}", from_device_id);
+            return false;
+        }
+    };
+
+    let dkg = match guard.unified_dkg.as_mut() {
+        Some(d) => d,
+        None => {
+            warn!("unified DKG: round1 arrived before our start_round1 ran — ignoring");
+            return false;
+        }
+    };
+    if let Err(e) = dkg.add_round1_package(from_index, &package) {
+        error!("unified DKG: add_round1_package({}) failed: {}", from_index, e);
+        return false;
+    }
+    let ready = dkg.can_start_round2();
+    info!(
+        "unified DKG: ingested round1 from {} (index {}); can_start_round2={}",
+        from_device_id, from_index, ready
+    );
+    ready
+}
+
+/// Run part2 for both curves; returns the per-recipient round-2 packages to send.
+pub async fn start_round2<C>(state: Arc<Mutex<AppState<C>>>) -> Option<UnifiedRound2Message>
+where
+    C: Ciphersuite + Send + Sync + 'static,
+{
+    let mut guard = state.lock().await;
+    let from_index = guard.unified_dkg.as_ref().map(|d| d.participant_index())?;
+    let dkg = guard.unified_dkg.as_mut()?;
+    match dkg.generate_round2() {
+        Ok(UnifiedRound2Packages { ed25519, secp256k1 }) => {
+            guard.dkg_state = crate::utils::state::DkgState::Round2InProgress;
+            info!(
+                "unified DKG: round 2 generated ({} ed / {} secp recipients)",
+                ed25519.len(),
+                secp256k1.len()
+            );
+            Some(UnifiedRound2Message {
+                from_index,
+                ed25519,
+                secp256k1,
+            })
+        }
+        Err(e) => {
+            error!("unified DKG: generate_round2 failed: {}", e);
+            guard.dkg_state =
+                crate::utils::state::DkgState::Failed(format!("unified round2: {e}"));
+            None
+        }
+    }
+}
+
+/// Fold in a peer's round-2 message (we pick out the entry addressed to us).
+/// Returns `true` when DKG can be finalized.
+pub async fn ingest_round2<C>(
+    state: Arc<Mutex<AppState<C>>>,
+    msg: UnifiedRound2Message,
+) -> bool
+where
+    C: Ciphersuite + Send + Sync + 'static,
+{
+    let mut guard = state.lock().await;
+    let my_index = match guard.unified_dkg.as_ref() {
+        Some(d) => d.participant_index(),
+        None => {
+            warn!("unified DKG: round2 arrived before our DKG was initialised — ignoring");
+            return false;
+        }
+    };
+
+    // Pick out the package addressed to us from the sender's per-recipient maps.
+    let ed_hex = match msg.ed25519.get(&my_index) {
+        Some(h) => h.clone(),
+        None => {
+            warn!(
+                "unified DKG: round2 from index {} has no ed25519 package for us (index {})",
+                msg.from_index, my_index
+            );
+            return false;
+        }
+    };
+    let secp_hex = match msg.secp256k1.get(&my_index) {
+        Some(h) => h.clone(),
+        None => {
+            warn!(
+                "unified DKG: round2 from index {} has no secp256k1 package for us (index {})",
+                msg.from_index, my_index
+            );
+            return false;
+        }
+    };
+
+    let dkg = match guard.unified_dkg.as_mut() {
+        Some(d) => d,
+        None => return false,
+    };
+    if let Err(e) = dkg.add_round2_package(msg.from_index, &ed_hex, &secp_hex) {
+        error!(
+            "unified DKG: add_round2_package({}) failed: {}",
+            msg.from_index, e
+        );
+        return false;
+    }
+    let ready = dkg.can_finalize();
+    info!(
+        "unified DKG: ingested round2 from index {}; can_finalize={}",
+        msg.from_index, ready
+    );
+    ready
+}
+
+/// Whether the unified DKG has all it needs to run part3 (both curves).
+/// Used to catch the round-2-before-round-1 race: a peer's round-2 package can
+/// land before our own part2 ran, so after we generate round 2 we re-check this.
+pub async fn can_finalize<C>(state: Arc<Mutex<AppState<C>>>) -> bool
+where
+    C: Ciphersuite + Send + Sync + 'static,
+{
+    let guard = state.lock().await;
+    guard
+        .unified_dkg
+        .as_ref()
+        .map(|d| d.can_finalize())
+        .unwrap_or(false)
+}
+
+/// Run part3 for both curves, persist the wallet under BOTH `ed25519/` and
+/// `secp256k1/` keystore dirs, and return the outcome (group keys + addresses).
+///
+/// `wallet_id` is the session-derived id (shared cluster-wide). The persisted
+/// share blobs use the exact same `[kp_len][kp][pkp_len][pkp]` framing the
+/// single-curve path writes, so the resulting wallets are signing-compatible.
+pub async fn finalize<C>(
+    state: Arc<Mutex<AppState<C>>>,
+    wallet_id: String,
+    password: String,
+    keystore_path: String,
+    wallet_label: Option<String>,
+) -> Option<UnifiedDkgOutcome>
+where
+    C: Ciphersuite + Send + Sync + 'static,
+{
+    let mut guard = state.lock().await;
+
+    if matches!(guard.dkg_state, crate::utils::state::DkgState::Complete) {
+        return None; // idempotent: already finalized
+    }
+
+    let session = guard.session.clone()?;
+    let device_id = guard.device_id.clone();
+
+    let dkg = guard.unified_dkg.as_mut()?;
+    if let Err(e) = dkg.finalize_dkg() {
+        error!("unified DKG: finalize_dkg failed: {}", e);
+        guard.dkg_state =
+            crate::utils::state::DkgState::Failed(format!("unified finalize: {e}"));
+        return None;
+    }
+
+    // Pull both group keys + canonical addresses out of the finished DKG.
+    let ed_group = dkg.get_ed25519_group_public_key().ok()?;
+    let secp_group = dkg.get_secp256k1_group_public_key().ok()?;
+    let solana_address = dkg.get_solana_address().unwrap_or_default();
+    let eth_address = dkg.get_eth_address().unwrap_or_default();
+
+    // Frame each curve's (KeyPackage, PublicKeyPackage) into the keystore blob.
+    // `frost_ed25519::keys::KeyPackage` IS `KeyPackage<Ed25519Sha512>`, so the
+    // generic blob encoder works directly.
+    let ed_blob = match (dkg.ed25519_key_package(), dkg.ed25519_public_key_package()) {
+        (Some(kp), Some(pkp)) => match crate::elm::command::encode_keystore_blob(kp, pkp) {
+            Ok(b) => b,
+            Err(e) => {
+                error!("unified DKG: ed25519 blob encode failed: {}", e);
+                return None;
+            }
+        },
+        _ => {
+            error!("unified DKG: missing ed25519 key packages after finalize");
+            return None;
+        }
+    };
+    let secp_blob = match (
+        dkg.secp256k1_key_package(),
+        dkg.secp256k1_public_key_package(),
+    ) {
+        (Some(kp), Some(pkp)) => match crate::elm::command::encode_keystore_blob(kp, pkp) {
+            Ok(b) => b,
+            Err(e) => {
+                error!("unified DKG: secp256k1 blob encode failed: {}", e);
+                return None;
+            }
+        },
+        _ => {
+            error!("unified DKG: missing secp256k1 key packages after finalize");
+            return None;
+        }
+    };
+
+    guard.dkg_state = crate::utils::state::DkgState::Complete;
+    guard.current_wallet_id = Some(wallet_id.clone());
+    // Drop the borrow before we touch the keystore.
+    drop(guard);
+
+    // Canonical (sorted) participant order — same as the single-curve path so
+    // the persisted participant_index matches every node's FROST identifier.
+    let mut sorted = session.participants.clone();
+    sorted.sort();
+    let participant_index = match sorted.iter().position(|p| p == &device_id) {
+        Some(idx) => (idx as u16) + 1,
+        None => {
+            error!("unified DKG: device_id {} not in participants", device_id);
+            return None;
+        }
+    };
+
+    use crate::keystore::Keystore;
+    let mut ks = match Keystore::new(&keystore_path, &device_id) {
+        Ok(k) => k,
+        Err(e) => {
+            error!("unified DKG: Keystore::new failed: {}", e);
+            return None;
+        }
+    };
+
+    // Persist BOTH curves under the same wallet_id (different curve dirs).
+    if let Err(e) = ks.create_wallet_unified(
+        &wallet_id,
+        session.threshold,
+        session.total,
+        participant_index,
+        sorted.clone(),
+        wallet_label,
+        &password,
+        &ed_group,
+        &ed_blob,
+        &secp_group,
+        &secp_blob,
+    ) {
+        error!("unified DKG: persist both curves failed: {}", e);
+        return None;
+    }
+    info!("unified DKG: persisted ed25519 + secp256k1 shares for wallet {}", wallet_id);
+    drop(password);
+
+    // Re-hydrate the shared read-only keystore so the next LoadWallets sees both.
+    if let Ok(fresh) = Keystore::new(&keystore_path, &device_id) {
+        let mut state = state.lock().await;
+        state.keystore = Some(Arc::new(fresh));
+    }
+
+    info!(
+        "✅ unified DKG complete: wallet={} eth={} sol={}",
+        wallet_id, eth_address, solana_address
+    );
+    Some(UnifiedDkgOutcome {
+        wallet_id,
+        ed25519_group_public_key: ed_group,
+        secp256k1_group_public_key: secp_group,
+        solana_address,
+        eth_address,
+    })
+}

--- a/apps/tui-node/src/utils/appstate_compat.rs
+++ b/apps/tui-node/src/utils/appstate_compat.rs
@@ -124,6 +124,20 @@ pub struct AppState<C: Ciphersuite> {
         Option<tokio::sync::broadcast::Sender<Arc<webrtc_signal_server::ServerMsg>>>,
     // ICE candidate queue for handling race conditions
     pub ice_candidate_queue: Arc<tokio::sync::Mutex<std::collections::HashMap<String, Vec<webrtc::ice_transport::ice_candidate::RTCIceCandidateInit>>>>,
+
+    // --- Unified DKG (ed25519 + secp256k1 from one ceremony) ---
+    /// True when this node is running a UNIFIED ceremony (curve_type == "unified").
+    /// Set by the creator (from the model flag) or the joiner (from the announce).
+    /// When set, the mesh-ready trigger runs `protocal::unified_dkg` instead of
+    /// the single-curve `protocal::dkg`, and the generic `C` DKG fields are unused.
+    pub unified_mode: bool,
+    /// The concrete unified-DKG driver state (both curves). Lives here because
+    /// it is NOT generic over `C`; the unified path ignores `C` entirely.
+    pub unified_dkg: Option<frost_mpc_core::unified_dkg::UnifiedDkg>,
+    /// Finalize context (password, keystore_path, optional label) captured when
+    /// the unified ceremony is triggered, so the round-2 completion can persist
+    /// without re-threading these through every message.
+    pub unified_finalize: Option<(String, String, Option<String>)>,
 }
 
 impl<C: Ciphersuite + Send + Sync + 'static> Default for AppState<C>
@@ -215,6 +229,9 @@ where
             websocket_msg_tx: None,
             server_msg_broadcast_tx: None,
             ice_candidate_queue: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
+            unified_mode: false,
+            unified_dkg: None,
+            unified_finalize: None,
         }
     }
     
@@ -296,6 +313,9 @@ where
             websocket_msg_tx: None,
             server_msg_broadcast_tx: None,
             ice_candidate_queue: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
+            unified_mode: false,
+            unified_dkg: None,
+            unified_finalize: None,
         }
     }
     


### PR DESCRIPTION
Drives frost-core's `UnifiedDkg` over the WebRTC mesh so **one DKG ceremony produces a wallet holding both ed25519 + secp256k1 keys** from a single root secret → Ethereum/Bitcoin (secp256k1) + Solana/Sui (ed25519) in one wallet. (The browser/core-wasm already did unified; this brings tui-node/CLI to parity, for the desktop.)

## What
- **Driver** `protocal/unified_dkg.rs`: transport-agnostic start/ingest round1 → round2 (targeted) → finalize, bundling both curves per round (`UnifiedRound1Package` / `UnifiedRound2Message`).
- **Keystore** `create_wallet_unified`: same `wallet_id` saved under both `ed25519/` and `secp256k1/` (atomic).
- **Mesh + Elm wiring**: `--curve unified` flows through create / join / announce (`curve_type:"unified"`); mesh-ready triggers the unified round1; `dispatch_data_channel_msg` routes the two unified frames; finalize → `create_wallet_unified` → `dkg_complete`.
- Single-curve path untouched (default when `curve != "unified"`).

## Wire shape (data channel)
- `UNIFIED_DKG_ROUND1:<{ed25519,secp256k1} hex>` — broadcast.
- `UNIFIED_DKG_ROUND2:<{from_index, ed25519:{idx→hex}, secp256k1:{idx→hex}}>` — each peer takes its own index.

## Verified (real separate processes, local signal server)
- 2-of-2 + 2-of-3 `--curve unified`: every node finishes; keystore holds the wallet under **both** curves; group keys unanimous.
- One wallet → ETH `0xa005d934…` (secp256k1) + Solana (ed25519).
- 98/98 tui-node lib tests pass; single-curve `ceremony.sh` still works (no regression).

Follow-up: Stage 4 (starlab-desktop) consumes this to show all chains per wallet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)