### PR TITLE
chore(npm): rename npm scope @starlab → @stars-labs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v4
 
       # The extension tests load the REAL core-wasm glue (not a mock) and import
-      # @starlab/types subpaths (e.g. .../dkg) that resolve to the types
+      # @stars-labs/types subpaths (e.g. .../dkg) that resolve to the types
       # package's `dist/` — neither is committed, so both must be built here.
       - name: Install Rust toolchain (wasm32 for wasm-pack)
         uses: dtolnay/rust-toolchain@stable
@@ -94,7 +94,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
 
       # `--ignore-scripts`: the extension's postinstall (`wxt prepare`) imports
-      # @starlab/types/* and would fail before `dist/` exists. Skip lifecycle
+      # @stars-labs/types/* and would fail before `dist/` exists. Skip lifecycle
       # scripts at install, build the deps, then prepare explicitly.
       - run: bun install --frozen-lockfile --ignore-scripts
 
@@ -103,8 +103,8 @@ jobs:
       - name: Build core-wasm (tests load the real WASM glue)
         run: cd packages/@starlab/core-wasm && wasm-pack build --target web --out-dir pkg
 
-      - name: Build shared types (provides @starlab/types/* dist subpaths)
-        run: bun run --filter '@starlab/types' build
+      - name: Build shared types (provides @stars-labs/types/* dist subpaths)
+        run: bun run --filter '@stars-labs/types' build
 
       - name: Prepare WXT (now that types dist exists)
         run: cd apps/browser-extension && bunx wxt prepare

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -54,14 +54,14 @@ jobs:
       - uses: oven-sh/setup-bun@v2
 
       # `--ignore-scripts`: the extension's postinstall (`wxt prepare`) imports
-      # @starlab/types/* and would fail before its dist/ exists. Build the
+      # @stars-labs/types/* and would fail before its dist/ exists. Build the
       # deps first, then prepare — mirrors the `extension` job in ci.yml.
       - run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Build core-wasm (the extension loads the real WASM FROST glue)
         run: cd packages/@starlab/core-wasm && wasm-pack build --target web --out-dir pkg
-      - name: Build shared types (@starlab/types/* dist subpaths)
-        run: bun run --filter '@starlab/types' build
+      - name: Build shared types (@stars-labs/types/* dist subpaths)
+        run: bun run --filter '@stars-labs/types' build
       - name: Prepare WXT (now that types dist exists)
         run: cd apps/browser-extension && bunx wxt prepare
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ The extension is a standalone MPC client with TUI wire-protocol parity — any c
 
 1. **Popup** (`src/entrypoints/popup/App.svelte`) — Svelte 5 legacy reactivity (NOT runes). Lives only while the browser-action panel is open. Talks to background via `chrome.runtime.connect({name: "popup"})`.
 2. **Background SW** (`src/entrypoints/background/`) — Orchestrates. Owns `StateManager`, `SessionManager`, `WebSocketManager` (signal server), `OffscreenManager`. MV3 service workers terminate after ~30s idle; `KeepaliveController` pings during active DKG/signing states to prevent death.
-3. **Offscreen** (`src/entrypoints/offscreen/`) — Long-lived WebRTC + WASM host. Loads `@starlab/core-wasm` (FROST); holds `WebRTCManager` with all FROST state (`frostDkg`, `signingInfo`, `signingCommitments` Map, `signingShares` Map). Background↔offscreen communicate via `chrome.runtime.sendMessage` wrapped in `{type: "fromBackground"|"fromOffscreen", payload}`.
+3. **Offscreen** (`src/entrypoints/offscreen/`) — Long-lived WebRTC + WASM host. Loads `@stars-labs/core-wasm` (FROST); holds `WebRTCManager` with all FROST state (`frostDkg`, `signingInfo`, `signingCommitments` Map, `signingShares` Map). Background↔offscreen communicate via `chrome.runtime.sendMessage` wrapped in `{type: "fromBackground"|"fromOffscreen", payload}`.
 4. **Content + injected** — Injects an EIP-1193 provider into page context. The provider is scoped to `window.starlabEthereum` only (never `window.ethereum`, to coexist with other wallet extensions); dApps discover it via EIP-6963 `eip6963:announceProvider` events. `window.starlabEthereum.request({method: 'personal_sign', ...})` → content script → `background.rpcHandler.handleSignMessageRequest`.
 
 ### Signing pipeline (end-to-end)
@@ -151,7 +151,7 @@ signal server. The consumer GUI products are separate:
   `starlab_export` / `starlab_import` (see `starlab-client`'s `offline_manager.rs`)
   — a mismatch breaks desktop↔TUI air-gap interop.
 - **Browser extension** — being split into `stars-labs/starlab-wallet`
-  (FROST + YubiKey + sandbox execution); consumes `@starlab/core-wasm`.
+  (FROST + YubiKey + sandbox execution); consumes `@stars-labs/core-wasm`.
 
 When changing `starlab-client::core` (`WalletManager`, `SessionManager`, `DkgManager`,
 `SigningManager`, `OfflineManager`, `ConnectionManager`, `CoreState`) or

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Also published: `starlab-core-wasm` (browser bindings), `starlab-client` (engine
 **TypeScript (npm):**
 
 ```bash
-npm install @starlab/core-wasm @starlab/types
+npm install @stars-labs/core-wasm @stars-labs/types
 ```
 
 ## Quick Start
@@ -163,7 +163,7 @@ starlab-mpc/
 │   ├── core/                     # FROST protocol core (crate: starlab-core)
 │   ├── core-wasm/                # WebAssembly bindings (crate: starlab-core-wasm)
 │   ├── blockchain/               # Multi-chain support (EVM / Bitcoin / Solana / Sui)
-│   └── types/                    # TypeScript type definitions (@starlab/types)
+│   └── types/                    # TypeScript type definitions (@stars-labs/types)
 │
 ├── docs/                         # Documentation
 └── scripts/                      # Build, test, and operational scripts
@@ -280,7 +280,7 @@ We welcome contributions! Please see our [Contributing Guide](docs/CONTRIBUTING.
   **[stars-labs/starlab-desktop](https://github.com/stars-labs/starlab-desktop)**
 - [x] Cloudflare Worker signal server (Rust-over-WASM) and
   standalone `cargo`-built signal server
-- [x] Published to crates.io (`starlab-*`) and npm (`@starlab/*`)
+- [x] Published to crates.io (`starlab-*`) and npm (`@stars-labs/*`)
 
 ### Open work (no committed timelines)
 

--- a/apps/browser-extension/docs/ARCHITECTURE.md
+++ b/apps/browser-extension/docs/ARCHITECTURE.md
@@ -100,7 +100,7 @@ reactivity, NOT runes — see the top-of-repo `CLAUDE.md`)
 **Responsibilities:**
 - WebRTC peer-connection lifecycle + data channels
 - P2P DKG / signing ceremony execution
-- FROST-WASM host (loads `@starlab/core-wasm` → `frostDkg`)
+- FROST-WASM host (loads `@stars-labs/core-wasm` → `frostDkg`)
 - DOM-dependent operations that can't run in the MV3 service
   worker context
 
@@ -807,7 +807,7 @@ sessionManager.proposeSession(/* sessionId, total, threshold,
 sessionManager.acceptSession(sessionId, blockchain)
 //   -> relays the session response + triggers mesh setup
 
-// Mesh Status Tracking (shared type, from @starlab/types):
+// Mesh Status Tracking (shared type, from @stars-labs/types):
 enum MeshStatusType {
     Incomplete,
     PartiallyReady,

--- a/apps/browser-extension/docs/README.md
+++ b/apps/browser-extension/docs/README.md
@@ -119,7 +119,7 @@ apps/browser-extension/
 ├── wxt.config.ts         # WXT framework config
 └── package.json          # Bun workspace member
 
-# Types and shared schemas live in the workspace `@starlab/types`
+# Types and shared schemas live in the workspace `@stars-labs/types`
 # package, NOT under the extension's own `src/`:
 packages/@starlab/types/src/
 ├── messages.ts           # All cross-context message types

--- a/apps/browser-extension/package.json
+++ b/apps/browser-extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@starlab/browser-extension",
+  "name": "@stars-labs/browser-extension",
   "description": "MPC Wallet Browser Extension",
   "private": true,
   "version": "0.0.0",
@@ -41,8 +41,8 @@
     "wxt": "^0.20.26"
   },
   "dependencies": {
-    "@starlab/core-wasm": "workspace:*",
-    "@starlab/types": "workspace:*",
+    "@stars-labs/core-wasm": "workspace:*",
+    "@stars-labs/types": "workspace:*",
     "@tailwindcss/vite": "^4.3.0",
     "tailwindcss": "^4.3.0",
     "uuid": "^14.0.0",

--- a/apps/browser-extension/scripts/gen-frost-fixtures.ts
+++ b/apps/browser-extension/scripts/gen-frost-fixtures.ts
@@ -7,7 +7,7 @@
 // for a given WASM build — regenerate whenever the on-disk
 // keystore schema in packages/@starlab/core changes.
 
-import wasmInit, { FrostDkgSecp256k1, FrostDkgEd25519 } from '@starlab/core-wasm';
+import wasmInit, { FrostDkgSecp256k1, FrostDkgEd25519 } from '@stars-labs/core-wasm';
 import { writeFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';

--- a/apps/browser-extension/src/components/AccountManager.svelte
+++ b/apps/browser-extension/src/components/AccountManager.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { onMount } from 'svelte';
-    import type { Account } from "@starlab/types/account";
+    import type { Account } from "@stars-labs/types/account";
     import AccountService from '../services/accountService';
     
     export let blockchain: 'ethereum' | 'solana' = 'ethereum';

--- a/apps/browser-extension/src/components/CreateWalletForm.svelte
+++ b/apps/browser-extension/src/components/CreateWalletForm.svelte
@@ -8,7 +8,7 @@
      * This is the DKG *initiator* flow only. Joiner side is Ext-1e.
      */
     import { createEventDispatcher } from "svelte";
-    import { MESSAGE_TYPES } from "@starlab/types/messages";
+    import { MESSAGE_TYPES } from "@stars-labs/types/messages";
     import Button from "../lib/ui/Button.svelte";
     import Icon from "../lib/ui/Icon.svelte";
     import { guideError } from "../utils/error-guidance";

--- a/apps/browser-extension/src/components/Settings.svelte
+++ b/apps/browser-extension/src/components/Settings.svelte
@@ -2,13 +2,13 @@
     import { onMount } from "svelte";
     import NetworkService from "../services/networkService";
     import { mainnet } from "viem/chains";
-    import type { Chain } from "@starlab/types/network";
-    import type { SupportedChain } from "@starlab/types/appstate";
+    import type { Chain } from "@stars-labs/types/network";
+    import type { SupportedChain } from "@stars-labs/types/appstate";
     import {
         CURVE_COMPATIBLE_CHAINS,
         getCompatibleChains,
         getRequiredCurve,
-    } from "@starlab/types/appstate";
+    } from "@stars-labs/types/appstate";
     import { createPublicClient, http } from "viem";
     import { createEventDispatcher } from "svelte";
     import { themeMode, setTheme, type ThemeMode } from "../lib/theme";

--- a/apps/browser-extension/src/entrypoints/background/index.ts
+++ b/apps/browser-extension/src/entrypoints/background/index.ts
@@ -35,11 +35,11 @@ import { PopupMessageHandler, OffscreenMessageHandler } from './messageHandlers'
 import { KeepaliveController } from './keepaliveController';
 
 // Import types
-import { AppState, INITIAL_APP_STATE } from "@starlab/types/appstate";
-import { SessionProposal, SessionResponse, SessionInfo } from "@starlab/types/session";
+import { AppState, INITIAL_APP_STATE } from "@stars-labs/types/appstate";
+import { SessionProposal, SessionResponse, SessionInfo } from "@stars-labs/types/session";
 import { getSignalServerUrl } from "../../config/signal-server";
-import { MeshStatusType, MeshStatus } from "@starlab/types/mesh";
-import { DkgState } from "@starlab/types/dkg";
+import { MeshStatusType, MeshStatus } from "@stars-labs/types/mesh";
+import { DkgState } from "@stars-labs/types/dkg";
 import {
     type JsonRpcRequest,
     type PopupToBackgroundMessage,
@@ -60,8 +60,8 @@ import {
     type BackgroundMessage,
     type OffscreenMessage,
     type PopupMessage,
-} from "@starlab/types/messages";
-import { ServerMsg, ClientMsg, WebSocketMessagePayload, WebRTCSignal } from "@starlab/types/websocket";
+} from "@stars-labs/types/messages";
+import { ServerMsg, ClientMsg, WebSocketMessagePayload, WebRTCSignal } from "@stars-labs/types/websocket";
 
 // ===================================================================
 // SERVICE INITIALIZATION AND GLOBAL STATE

--- a/apps/browser-extension/src/entrypoints/background/keepaliveController.ts
+++ b/apps/browser-extension/src/entrypoints/background/keepaliveController.ts
@@ -23,7 +23,7 @@
 // that IS happening doesn't die under our feet.
 // ===================================================================
 
-import { DkgState } from "@starlab/types/dkg";
+import { DkgState } from "@stars-labs/types/dkg";
 
 /** Message shape sent to offscreen. Must carry `target: "offscreen"`
  *  so the offscreen entrypoint routes it correctly and non-offscreen

--- a/apps/browser-extension/src/entrypoints/background/messageHandlers.ts
+++ b/apps/browser-extension/src/entrypoints/background/messageHandlers.ts
@@ -13,8 +13,8 @@
 import type {
     PopupToBackgroundMessage,
     OffscreenToBackgroundMessage
-} from "@starlab/types/messages";
-import { MESSAGE_TYPES, isRpcMessage, isAccountManagement, isNetworkManagement, isUIRequest } from "@starlab/types/messages";
+} from "@stars-labs/types/messages";
+import { MESSAGE_TYPES, isRpcMessage, isAccountManagement, isNetworkManagement, isUIRequest } from "@stars-labs/types/messages";
 import { StateManager } from "./stateManager";
 import { OffscreenManager } from "./offscreenManager";
 import { WebSocketManager } from "./webSocketManager";
@@ -23,7 +23,7 @@ import { checkAndRestoreKeystores } from "./index";
 import { RpcHandler, UIRequestHandler } from "./rpcHandler";
 import AccountService from "../../services/accountService";
 import { KeystoreManager } from "../../services/keystoreManager";
-import { DkgState } from "@starlab/types/dkg";
+import { DkgState } from "@stars-labs/types/dkg";
 
 /**
  * Handles messages from popup interface

--- a/apps/browser-extension/src/entrypoints/background/offscreenManager.ts
+++ b/apps/browser-extension/src/entrypoints/background/offscreenManager.ts
@@ -12,8 +12,8 @@
 import type {
     BackgroundToOffscreenWrapper,
     OffscreenMessage
-} from "@starlab/types/messages";
-import { AppState } from "@starlab/types/appstate";
+} from "@stars-labs/types/messages";
+import { AppState } from "@stars-labs/types/appstate";
 import { getSignalServerUrl } from "../../config/signal-server";
 
 /**

--- a/apps/browser-extension/src/entrypoints/background/rpcHandler.ts
+++ b/apps/browser-extension/src/entrypoints/background/rpcHandler.ts
@@ -14,7 +14,7 @@ import WalletClientService from '../../services/walletClient';
 import WalletController from "../../services/walletController";
 import { getPermissionService } from '../../services/permissionService';
 import { toHex } from 'viem';
-import type { JsonRpcRequest } from "@starlab/types/messages";
+import type { JsonRpcRequest } from "@stars-labs/types/messages";
 import type { SessionManager } from './sessionManager';
 
 /**

--- a/apps/browser-extension/src/entrypoints/background/sessionManager.ts
+++ b/apps/browser-extension/src/entrypoints/background/sessionManager.ts
@@ -9,13 +9,13 @@
 // - Session state validation
 // ===================================================================
 
-import { AppState } from "@starlab/types/appstate";
-import { SessionInfo, SessionProposal, SessionResponse } from "@starlab/types/session";
-import { MeshStatus } from "@starlab/types/mesh";
-import { DkgState } from "@starlab/types/dkg";
+import { AppState } from "@stars-labs/types/appstate";
+import { SessionInfo, SessionProposal, SessionResponse } from "@stars-labs/types/session";
+import { MeshStatus } from "@stars-labs/types/mesh";
+import { DkgState } from "@stars-labs/types/dkg";
 import { WebSocketClient } from "./websocket";
-import { validateSessionProposal, validateSessionAcceptance } from "@starlab/types/messages";
-import type { BackgroundToPopupMessage, OffscreenMessage } from "@starlab/types/messages";
+import { validateSessionProposal, validateSessionAcceptance } from "@stars-labs/types/messages";
+import type { BackgroundToPopupMessage, OffscreenMessage } from "@stars-labs/types/messages";
 import { buildWireSessionInfo } from "../../utils/session-parse";
 
 // Session persistence removed - sessions are ephemeral for security

--- a/apps/browser-extension/src/entrypoints/background/signingNotification.ts
+++ b/apps/browser-extension/src/entrypoints/background/signingNotification.ts
@@ -24,7 +24,7 @@
  * signing invite via appState.invites.
  */
 
-import type { SessionInfo } from "@starlab/types/session";
+import type { SessionInfo } from "@stars-labs/types/session";
 
 const NOTIFICATION_ID_PREFIX = "mpc-signing-req:";
 

--- a/apps/browser-extension/src/entrypoints/background/stateManager.ts
+++ b/apps/browser-extension/src/entrypoints/background/stateManager.ts
@@ -11,14 +11,14 @@
 // - Cross-component state consistency
 // ===================================================================
 
-import { AppState, INITIAL_APP_STATE } from "@starlab/types/appstate";
-import { MeshStatusType } from "@starlab/types/mesh";
-import { DkgState } from "@starlab/types/dkg";
+import { AppState, INITIAL_APP_STATE } from "@stars-labs/types/appstate";
+import { MeshStatusType } from "@stars-labs/types/mesh";
+import { DkgState } from "@stars-labs/types/dkg";
 import type {
     BackgroundToPopupMessage,
     InitialStateMessage,
     OffscreenToBackgroundMessage
-} from "@starlab/types/messages";
+} from "@stars-labs/types/messages";
 
 /** Listener fired whenever `appState.dkgState` changes. Registered
  *  via `addDkgStateListener`. Used by the keepalive controller to

--- a/apps/browser-extension/src/entrypoints/background/webSocketManager.ts
+++ b/apps/browser-extension/src/entrypoints/background/webSocketManager.ts
@@ -11,8 +11,8 @@
 // ===================================================================
 
 import { WebSocketClient } from "./websocket";
-import { AppState } from "@starlab/types/appstate";
-import type { SessionInfo } from "@starlab/types/session";
+import { AppState } from "@stars-labs/types/appstate";
+import type { SessionInfo } from "@stars-labs/types/session";
 import { SessionManager } from "./sessionManager";
 import { SigningNotifier } from "./signingNotification";
 import { getSignalServerUrl } from "../../config/signal-server";
@@ -21,8 +21,8 @@ import type {
     BackgroundToPopupMessage,
     InitialStateMessage,
     OffscreenMessage
-} from "@starlab/types/messages";
-import { ServerMsg, WebSocketMessagePayload } from "@starlab/types/websocket";
+} from "@stars-labs/types/messages";
+import { ServerMsg, WebSocketMessagePayload } from "@stars-labs/types/websocket";
 
 /**
  * Manages WebSocket connections and message handling for MPC coordination

--- a/apps/browser-extension/src/entrypoints/background/websocket.ts
+++ b/apps/browser-extension/src/entrypoints/background/websocket.ts
@@ -4,7 +4,7 @@ import type {
     WebSocketClientMsg,
     WebSocketServerMsg,
     OffscreenToBackgroundMsg
-} from "@starlab/types/messages";
+} from "@stars-labs/types/messages";
 
 type MessageCallback = (message: WebSocketServerMsg) => void;
 type ErrorCallback = (error: Event) => void;

--- a/apps/browser-extension/src/entrypoints/content/provider.ts
+++ b/apps/browser-extension/src/entrypoints/content/provider.ts
@@ -6,7 +6,7 @@ import type {
     ContentToInjectedMsg,
     JsonRpcRequest,
     JsonRpcResponse
-} from "@starlab/types/messages";
+} from "@stars-labs/types/messages";
 
 // 定义消息接口
 export interface ContentMessage {

--- a/apps/browser-extension/src/entrypoints/offscreen/index.ts
+++ b/apps/browser-extension/src/entrypoints/offscreen/index.ts
@@ -1,10 +1,10 @@
 import { WebRTCManager } from './webrtc'; // Adjust path as necessary
-import type { SessionInfo, MeshStatus, DkgState } from "@starlab/types/appstate"; // Fixed import
-import type { WebRTCAppMessage } from "@starlab/types/webrtc";
-import { ServerMsg, ClientMsg, WebSocketMessagePayload, WebRTCSignal } from "@starlab/types/websocket";
+import type { SessionInfo, MeshStatus, DkgState } from "@stars-labs/types/appstate"; // Fixed import
+import type { WebRTCAppMessage } from "@stars-labs/types/webrtc";
+import { ServerMsg, ClientMsg, WebSocketMessagePayload, WebRTCSignal } from "@stars-labs/types/websocket";
 
 // Import WASM modules for FROST DKG
-import wasmInit, { FrostDkgEd25519, FrostDkgSecp256k1 } from '@starlab/core-wasm';
+import wasmInit, { FrostDkgEd25519, FrostDkgSecp256k1 } from '@stars-labs/core-wasm';
 
 console.log("Offscreen script loaded.");
 
@@ -352,7 +352,7 @@ chrome.runtime.onMessage.addListener((message: { type?: string; payload?: any },
                         console.log("Offscreen: Found active keystore to load");
                         
                         try {
-                            const { FrostDkgSecp256k1, FrostDkgEd25519 } = await import("@starlab/core-wasm");
+                            const { FrostDkgSecp256k1, FrostDkgEd25519 } = await import("@stars-labs/core-wasm");
                             
                             // Determine curve type
                             const curveType = response.keyShare.curve || 'secp256k1';

--- a/apps/browser-extension/src/entrypoints/offscreen/webrtc.environment.test.ts
+++ b/apps/browser-extension/src/entrypoints/offscreen/webrtc.environment.test.ts
@@ -1,7 +1,7 @@
 // Environment difference test for FROST DKG in production vs test
 import { describe, it, test, expect, beforeAll, beforeEach, afterEach, afterAll, jest } from 'bun:test';
 import { DkgState, WebRTCManager } from './webrtc';
-import wasmInit, { FrostDkgEd25519, FrostDkgSecp256k1 } from '@starlab/core-wasm';
+import wasmInit, { FrostDkgEd25519, FrostDkgSecp256k1 } from '@stars-labs/core-wasm';
 
 describe('FROST DKG Environment Difference Analysis', () => {
   let wasmInitialized = false;

--- a/apps/browser-extension/src/entrypoints/offscreen/webrtc.test.ts
+++ b/apps/browser-extension/src/entrypoints/offscreen/webrtc.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll } from 'bun:test';
 import { DkgState, WebRTCManager, MeshStatusType } from './webrtc'; // Adjust path as necessary
 import { Buffer } from 'buffer';
-import wasmInit, { FrostDkgEd25519, FrostDkgSecp256k1 } from '@starlab/core-wasm'; // Corrected import
+import wasmInit, { FrostDkgEd25519, FrostDkgSecp256k1 } from '@stars-labs/core-wasm'; // Corrected import
 
 function hexEncode(str: string): string {
     return Buffer.from(str, 'utf8').toString('hex');

--- a/apps/browser-extension/src/entrypoints/offscreen/webrtc.ts
+++ b/apps/browser-extension/src/entrypoints/offscreen/webrtc.ts
@@ -1,6 +1,6 @@
-import { SessionInfo, DkgState, MeshStatus, MeshStatusType } from "@starlab/types/appstate";
-import { WebRTCAppMessage } from "@starlab/types/webrtc";
-import { WebSocketMessagePayload, WebRTCSignal } from "@starlab/types/websocket";
+import { SessionInfo, DkgState, MeshStatus, MeshStatusType } from "@stars-labs/types/appstate";
+import { WebRTCAppMessage } from "@stars-labs/types/webrtc";
+import { WebSocketMessagePayload, WebRTCSignal } from "@stars-labs/types/websocket";
 
 export { DkgState, MeshStatusType }; // Export DkgState and MeshStatusType
 
@@ -1827,7 +1827,7 @@ export class WebRTCManager {
     );
 
     const { FrostDkgSecp256k1, FrostDkgEd25519 } = await import(
-      "@starlab/core-wasm"
+      "@stars-labs/core-wasm"
     );
     const instance =
       blockchain === "ethereum"

--- a/apps/browser-extension/src/entrypoints/popup/App.svelte
+++ b/apps/browser-extension/src/entrypoints/popup/App.svelte
@@ -14,17 +14,17 @@
     import { guideError } from "../../utils/error-guidance";
     import Collapsible from "../../lib/ui/Collapsible.svelte";
     import { storage } from "#imports";
-    import type { AppState } from "@starlab/types/appstate";
-    import { MeshStatusType } from "@starlab/types/mesh";
-    import { DkgState } from "@starlab/types/dkg";
-    import { INITIAL_APP_STATE } from "@starlab/types/appstate";
+    import type { AppState } from "@stars-labs/types/appstate";
+    import { MeshStatusType } from "@stars-labs/types/mesh";
+    import { DkgState } from "@stars-labs/types/dkg";
+    import { INITIAL_APP_STATE } from "@stars-labs/types/appstate";
     import Settings from "../../components/Settings.svelte";
     import AccountManager from "../../components/AccountManager.svelte";
     import SignatureRequest from "../../components/SignatureRequest.svelte";
     import PasswordPrompt from "./components/PasswordPrompt.svelte";
     import WalletSelector from "./components/WalletSelector.svelte";
     import CreateWalletForm from "../../components/CreateWalletForm.svelte";
-    import { MESSAGE_TYPES } from "@starlab/types/messages";
+    import { MESSAGE_TYPES } from "@stars-labs/types/messages";
     import { hashMessage } from "viem";
 
     // Theme (system | light | dark). initTheme() applies the saved mode
@@ -149,7 +149,7 @@
     // Review → join, or Later → dismiss (stays in invites list,
     // won't re-pop for this session_id). No auto-modal if we're
     // the proposer or already in an active ceremony.
-    let incomingSigningInvite: import("@starlab/types/session").SessionInfo | null = null;
+    let incomingSigningInvite: import("@stars-labs/types/session").SessionInfo | null = null;
     let dismissedSigningInvites: Set<string> = new Set();
 
     // Ext-3c: proposer-side toast when a co-signer explicitly
@@ -206,8 +206,8 @@
     let keystoreStatus: {
         initialized: boolean;
         locked: boolean;
-        wallets: import("@starlab/types/keystore").ExtensionWalletMetadata[];
-        activeWallet: import("@starlab/types/keystore").ExtensionWalletMetadata | null;
+        wallets: import("@stars-labs/types/keystore").ExtensionWalletMetadata[];
+        activeWallet: import("@stars-labs/types/keystore").ExtensionWalletMetadata | null;
         pendingImport: boolean;
     } = {
         initialized: false,
@@ -728,7 +728,7 @@
                 //   - not already in an active ceremony (busy signal)
                 {
                     const s = message.session as
-                        | import("@starlab/types/session").SessionInfo
+                        | import("@stars-labs/types/session").SessionInfo
                         | undefined;
                     if (!s) break;
                     if (s.session_type !== "signing") break;

--- a/apps/browser-extension/src/entrypoints/popup/components/WalletSelector.svelte
+++ b/apps/browser-extension/src/entrypoints/popup/components/WalletSelector.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { createEventDispatcher } from 'svelte';
-    import type { ExtensionWalletMetadata } from "@starlab/types/keystore";
+    import type { ExtensionWalletMetadata } from "@stars-labs/types/keystore";
     
     export let wallets: ExtensionWalletMetadata[] = [];
     export let activeWallet: ExtensionWalletMetadata | null = null;

--- a/apps/browser-extension/src/services/accountService.ts
+++ b/apps/browser-extension/src/services/accountService.ts
@@ -1,6 +1,6 @@
-import { Account } from "@starlab/types/account";
+import { Account } from "@stars-labs/types/account";
 import { KeystoreManager } from './keystoreManager';
-import type { NewAccountSession } from "@starlab/types/keystore";
+import type { NewAccountSession } from "@stars-labs/types/keystore";
 
 type AccountChangeCallback = (account: Account | null) => void;
 

--- a/apps/browser-extension/src/services/keystoreManager.ts
+++ b/apps/browser-extension/src/services/keystoreManager.ts
@@ -8,7 +8,7 @@
 // ===================================================================
 
 import { KeystoreService } from './keystoreService';
-import type { KeyShareData, ExtensionWalletMetadata } from "@starlab/types/keystore";
+import type { KeyShareData, ExtensionWalletMetadata } from "@stars-labs/types/keystore";
 
 interface KeystoreSession {
     unlocked: boolean;

--- a/apps/browser-extension/src/services/keystoreService.ts
+++ b/apps/browser-extension/src/services/keystoreService.ts
@@ -20,7 +20,7 @@ import type {
     WalletFile,
     BlockchainInfo,
     NewAccountSession
-} from "@starlab/types/keystore";
+} from "@stars-labs/types/keystore";
 
 export class KeystoreService {
     private static instance: KeystoreService;

--- a/apps/browser-extension/src/services/networkService.ts
+++ b/apps/browser-extension/src/services/networkService.ts
@@ -1,6 +1,6 @@
 import { mainnet, sepolia } from 'viem/chains';
-import type { Chain } from "@starlab/types/network";
-import type { SupportedChain } from "@starlab/types/appstate";
+import type { Chain } from "@stars-labs/types/network";
+import type { SupportedChain } from "@stars-labs/types/appstate";
 import { createPublicClient, http } from 'viem';
 
 type NetworkChangeCallback = (network: Chain | undefined) => void;

--- a/apps/browser-extension/src/utils/session-parse.ts
+++ b/apps/browser-extension/src/utils/session-parse.ts
@@ -19,7 +19,7 @@
  * caller (webSocketManager) logs and drops malformed payloads rather
  * than throwing.
  */
-import type { SessionInfo, SessionTypeTag } from "@starlab/types/session";
+import type { SessionInfo, SessionTypeTag } from "@stars-labs/types/session";
 
 export function parseSessionInfoFromWire(raw: unknown): SessionInfo | null {
     if (typeof raw !== "object" || raw === null) {

--- a/apps/browser-extension/tests/entrypoints/background/createDkgWallet.test.ts
+++ b/apps/browser-extension/tests/entrypoints/background/createDkgWallet.test.ts
@@ -8,9 +8,9 @@
  */
 import { describe, it, expect, beforeEach, mock, jest } from "bun:test";
 import { SessionManager } from "../../../src/entrypoints/background/sessionManager";
-import { DkgState } from "@starlab/types/dkg";
-import { MeshStatusType } from "@starlab/types/mesh";
-import type { AppState } from "@starlab/types/appstate";
+import { DkgState } from "@stars-labs/types/dkg";
+import { MeshStatusType } from "@stars-labs/types/mesh";
+import type { AppState } from "@stars-labs/types/appstate";
 
 function makeWsClientMock() {
     const announcedPayloads: Array<Record<string, unknown>> = [];

--- a/apps/browser-extension/tests/entrypoints/background/createSigningSession.test.ts
+++ b/apps/browser-extension/tests/entrypoints/background/createSigningSession.test.ts
@@ -9,9 +9,9 @@
  */
 import { describe, it, expect, beforeEach, jest } from "bun:test";
 import { SessionManager } from "../../../src/entrypoints/background/sessionManager";
-import { DkgState } from "@starlab/types/dkg";
-import { MeshStatusType } from "@starlab/types/mesh";
-import type { AppState } from "@starlab/types/appstate";
+import { DkgState } from "@stars-labs/types/dkg";
+import { MeshStatusType } from "@stars-labs/types/mesh";
+import type { AppState } from "@stars-labs/types/appstate";
 
 function makeSessionManager() {
     const appState: AppState = {

--- a/apps/browser-extension/tests/entrypoints/background/declineSigningHandler.test.ts
+++ b/apps/browser-extension/tests/entrypoints/background/declineSigningHandler.test.ts
@@ -16,10 +16,10 @@ import * as mockImports from "../../wxt-imports-mock";
 mock.module("#imports", () => mockImports);
 
 import { PopupMessageHandler } from "../../../src/entrypoints/background/messageHandlers";
-import type { SessionInfo } from "@starlab/types/session";
-import { DkgState } from "@starlab/types/dkg";
-import { MeshStatusType } from "@starlab/types/mesh";
-import type { AppState } from "@starlab/types/appstate";
+import type { SessionInfo } from "@stars-labs/types/session";
+import { DkgState } from "@stars-labs/types/dkg";
+import { MeshStatusType } from "@stars-labs/types/mesh";
+import type { AppState } from "@stars-labs/types/appstate";
 
 function signingInvite(overrides: Partial<SessionInfo> = {}): SessionInfo {
     return {

--- a/apps/browser-extension/tests/entrypoints/background/dkgAutoTrigger.test.ts
+++ b/apps/browser-extension/tests/entrypoints/background/dkgAutoTrigger.test.ts
@@ -24,10 +24,10 @@
  */
 import { describe, it, expect, beforeEach, jest } from "bun:test";
 import { WebSocketManager } from "../../../src/entrypoints/background/webSocketManager";
-import { DkgState } from "@starlab/types/dkg";
-import { MeshStatusType } from "@starlab/types/mesh";
-import type { AppState } from "@starlab/types/appstate";
-import type { SessionInfo } from "@starlab/types/session";
+import { DkgState } from "@stars-labs/types/dkg";
+import { MeshStatusType } from "@stars-labs/types/mesh";
+import type { AppState } from "@stars-labs/types/appstate";
+import type { SessionInfo } from "@stars-labs/types/session";
 
 function makeManager(opts?: {
     deviceId?: string;

--- a/apps/browser-extension/tests/entrypoints/background/dkgCompletePropagation.test.ts
+++ b/apps/browser-extension/tests/entrypoints/background/dkgCompletePropagation.test.ts
@@ -18,7 +18,7 @@
  */
 import { describe, it, expect, beforeEach, jest } from "bun:test";
 import { StateManager } from "../../../src/entrypoints/background/stateManager";
-import { DkgState } from "@starlab/types/dkg";
+import { DkgState } from "@stars-labs/types/dkg";
 
 describe("StateManager: dkgComplete propagation", () => {
     let mgr: StateManager;

--- a/apps/browser-extension/tests/entrypoints/background/joinDkgSession.test.ts
+++ b/apps/browser-extension/tests/entrypoints/background/joinDkgSession.test.ts
@@ -33,10 +33,10 @@
  */
 import { describe, it, expect, beforeEach, jest } from "bun:test";
 import { SessionManager } from "../../../src/entrypoints/background/sessionManager";
-import { DkgState } from "@starlab/types/dkg";
-import { MeshStatusType } from "@starlab/types/mesh";
-import type { AppState } from "@starlab/types/appstate";
-import type { SessionInfo } from "@starlab/types/session";
+import { DkgState } from "@stars-labs/types/dkg";
+import { MeshStatusType } from "@stars-labs/types/mesh";
+import type { AppState } from "@stars-labs/types/appstate";
+import type { SessionInfo } from "@stars-labs/types/session";
 
 function makeInvite(overrides: Partial<SessionInfo> = {}): SessionInfo {
     return {

--- a/apps/browser-extension/tests/entrypoints/background/keepaliveController.test.ts
+++ b/apps/browser-extension/tests/entrypoints/background/keepaliveController.test.ts
@@ -23,7 +23,7 @@
  *    the timer — the next interval still fires.
  */
 import { describe, it, expect, jest, beforeEach } from "bun:test";
-import { DkgState } from "@starlab/types/dkg";
+import { DkgState } from "@stars-labs/types/dkg";
 import {
     KeepaliveController,
     KEEPALIVE_INTERVAL_MS,

--- a/apps/browser-extension/tests/entrypoints/background/messageHandlers.test.ts
+++ b/apps/browser-extension/tests/entrypoints/background/messageHandlers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 // ExtensionMessage / ExtensionResponse were removed from
-// @starlab/types; the test file uses local `any` types for
+// @stars-labs/types; the test file uses local `any` types for
 // the mock handler signatures (messages are constructed inline
 // and only checked structurally).
 type ExtensionMessage = any;

--- a/apps/browser-extension/tests/entrypoints/background/sessionsForDevice.test.ts
+++ b/apps/browser-extension/tests/entrypoints/background/sessionsForDevice.test.ts
@@ -20,9 +20,9 @@
  */
 import { describe, it, expect, beforeEach, jest } from "bun:test";
 import { WebSocketManager } from "../../../src/entrypoints/background/webSocketManager";
-import { DkgState } from "@starlab/types/dkg";
-import { MeshStatusType } from "@starlab/types/mesh";
-import type { AppState } from "@starlab/types/appstate";
+import { DkgState } from "@stars-labs/types/dkg";
+import { MeshStatusType } from "@stars-labs/types/mesh";
+import type { AppState } from "@stars-labs/types/appstate";
 
 function makeAppState(): AppState {
     return {

--- a/apps/browser-extension/tests/entrypoints/background/signingAutoTrigger.test.ts
+++ b/apps/browser-extension/tests/entrypoints/background/signingAutoTrigger.test.ts
@@ -24,10 +24,10 @@
  */
 import { describe, it, expect, beforeEach, jest } from "bun:test";
 import { WebSocketManager } from "../../../src/entrypoints/background/webSocketManager";
-import { DkgState } from "@starlab/types/dkg";
-import { MeshStatusType } from "@starlab/types/mesh";
-import type { AppState } from "@starlab/types/appstate";
-import type { SessionInfo } from "@starlab/types/session";
+import { DkgState } from "@stars-labs/types/dkg";
+import { MeshStatusType } from "@stars-labs/types/mesh";
+import type { AppState } from "@stars-labs/types/appstate";
+import type { SessionInfo } from "@stars-labs/types/session";
 
 function makeManager(opts?: {
     deviceId?: string;

--- a/apps/browser-extension/tests/entrypoints/background/signingDecline.test.ts
+++ b/apps/browser-extension/tests/entrypoints/background/signingDecline.test.ts
@@ -20,10 +20,10 @@
  */
 import { describe, it, expect, beforeEach, jest } from "bun:test";
 import { WebSocketManager } from "../../../src/entrypoints/background/webSocketManager";
-import { DkgState } from "@starlab/types/dkg";
-import { MeshStatusType } from "@starlab/types/mesh";
-import type { AppState } from "@starlab/types/appstate";
-import type { SessionInfo } from "@starlab/types/session";
+import { DkgState } from "@stars-labs/types/dkg";
+import { MeshStatusType } from "@stars-labs/types/mesh";
+import type { AppState } from "@stars-labs/types/appstate";
+import type { SessionInfo } from "@stars-labs/types/session";
 
 function makeWsManager(opts?: {
     deviceId?: string;

--- a/apps/browser-extension/tests/entrypoints/background/signingNotification.test.ts
+++ b/apps/browser-extension/tests/entrypoints/background/signingNotification.test.ts
@@ -20,7 +20,7 @@ import {
     SigningNotifier,
     buildMessagePreview,
 } from "../../../src/entrypoints/background/signingNotification";
-import type { SessionInfo } from "@starlab/types/session";
+import type { SessionInfo } from "@stars-labs/types/session";
 
 function makeNotifier() {
     const calls: Array<{ id: string; options: any }> = [];

--- a/apps/browser-extension/tests/entrypoints/background/stateManagerDkgListener.test.ts
+++ b/apps/browser-extension/tests/entrypoints/background/stateManagerDkgListener.test.ts
@@ -15,8 +15,8 @@
  * 4. `unsubscribe()` actually detaches the listener.
  */
 import { describe, it, expect, jest, beforeEach } from "bun:test";
-import { DkgState } from "@starlab/types/dkg";
-import { MeshStatusType } from "@starlab/types/mesh";
+import { DkgState } from "@stars-labs/types/dkg";
+import { MeshStatusType } from "@stars-labs/types/mesh";
 import { StateManager } from "../../../src/entrypoints/background/stateManager";
 
 function makeStateManager() {

--- a/apps/browser-extension/tests/entrypoints/offscreen/test-utils.ts
+++ b/apps/browser-extension/tests/entrypoints/offscreen/test-utils.ts
@@ -1,5 +1,5 @@
 import { Buffer } from 'buffer';
-import wasmInit, { FrostDkgEd25519, FrostDkgSecp256k1 } from '@starlab/core-wasm';
+import wasmInit, { FrostDkgEd25519, FrostDkgSecp256k1 } from '@stars-labs/core-wasm';
 import fs from 'fs';
 import path from 'path';
 
@@ -12,7 +12,7 @@ export async function initializeWasmIfNeeded(): Promise<boolean> {
             // Previous versions of this helper read the WASM bytes from
             // `apps/browser-extension/pkg/starlab_mpc_bg.wasm` — a stale
             // path from before core-wasm was split into its own package.
-            // The @starlab/core-wasm entry (pkg/starlab_core_wasm.js)
+            // The @stars-labs/core-wasm entry (pkg/starlab_core_wasm.js)
             // resolves the adjacent .wasm file itself under Bun, so the
             // no-arg form works correctly.
             await wasmInit();

--- a/apps/browser-extension/tests/entrypoints/offscreen/webrtc.dkg.test.ts
+++ b/apps/browser-extension/tests/entrypoints/offscreen/webrtc.dkg.test.ts
@@ -9,7 +9,7 @@ import {
     createTestDkgInstances,
     cleanupDkgInstances
 } from './test-utils';
-import { FrostDkgEd25519, FrostDkgSecp256k1 } from '@starlab/core-wasm';
+import { FrostDkgEd25519, FrostDkgSecp256k1 } from '@stars-labs/core-wasm';
 
 let originalConsoleLog: any;
 let originalConsoleError: any;

--- a/apps/browser-extension/tests/entrypoints/offscreen/webrtc.environment.test.ts
+++ b/apps/browser-extension/tests/entrypoints/offscreen/webrtc.environment.test.ts
@@ -1,7 +1,7 @@
 // Environment difference test for FROST DKG in production vs test
 import { describe, it, test, expect, beforeAll, beforeEach, afterEach, afterAll, jest } from 'bun:test';
 import { DkgState, WebRTCManager } from '../../../src/entrypoints/offscreen/webrtc';
-import wasmInit, { FrostDkgEd25519, FrostDkgSecp256k1 } from '@starlab/core-wasm';
+import wasmInit, { FrostDkgEd25519, FrostDkgSecp256k1 } from '@stars-labs/core-wasm';
 let originalConsoleLog: any;
 let originalConsoleError: any;
 let originalConsoleWarn: any;

--- a/apps/browser-extension/tests/entrypoints/offscreen/webrtc.errors.test.ts
+++ b/apps/browser-extension/tests/entrypoints/offscreen/webrtc.errors.test.ts
@@ -7,7 +7,7 @@ import {
     dummySend,
     cleanupDkgInstances
 } from './test-utils';
-import { FrostDkgEd25519 } from '@starlab/core-wasm';
+import { FrostDkgEd25519 } from '@stars-labs/core-wasm';
 
 let manager: WebRTCManager;
 

--- a/apps/browser-extension/tests/entrypoints/offscreen/webrtc.signing.test.ts
+++ b/apps/browser-extension/tests/entrypoints/offscreen/webrtc.signing.test.ts
@@ -9,7 +9,7 @@ import {
     createTestDkgInstances,
     cleanupDkgInstances
 } from './test-utils';
-import { FrostDkgEd25519 } from '@starlab/core-wasm';
+import { FrostDkgEd25519 } from '@stars-labs/core-wasm';
 
 let originalConsoleLog: any;
 let originalConsoleError: any;

--- a/apps/browser-extension/tests/entrypoints/offscreen/webrtc.test.ts
+++ b/apps/browser-extension/tests/entrypoints/offscreen/webrtc.test.ts
@@ -1,5 +1,5 @@
 import { Buffer } from 'buffer';
-import wasmInit from '@starlab/core-wasm';
+import wasmInit from '@stars-labs/core-wasm';
 import { beforeAll } from 'bun:test';
 
 // Export helper functions for use in other test files

--- a/apps/browser-extension/tests/integration/extensionCliInterop.test.ts
+++ b/apps/browser-extension/tests/integration/extensionCliInterop.test.ts
@@ -1,5 +1,5 @@
 import { KeystoreService } from '../../src/services/keystoreService';
-import type { KeyShareData, KeystoreBackup } from "@starlab/types/keystore";
+import type { KeyShareData, KeystoreBackup } from "@stars-labs/types/keystore";
 // Mock CLI keystore format types
 import {  describe, it, expect, beforeEach } from 'bun:test';
 import { jest } from 'bun:test';

--- a/apps/browser-extension/tests/integration/keystore-persistence.test.ts
+++ b/apps/browser-extension/tests/integration/keystore-persistence.test.ts
@@ -3,7 +3,7 @@ import { REAL_WEBCRYPTO } from '../setup-bun';
 import { KeystoreManager } from '../../src/services/keystoreManager';
 import { KeystoreService } from '../../src/services/keystoreService';
 import { resetStorageData } from '../__mocks__/imports';
-import type { KeyShareData, ExtensionWalletMetadata } from "@starlab/types/keystore";
+import type { KeyShareData, ExtensionWalletMetadata } from "@stars-labs/types/keystore";
 
 // Mock chrome.storage
 const mockStorage = {

--- a/apps/browser-extension/tests/services/accountService.test.ts
+++ b/apps/browser-extension/tests/services/accountService.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 import AccountService from '../../src/services/accountService';
-import type { Account } from '@starlab/types/account';
+import type { Account } from '@stars-labs/types/account';
 
 // Helper function to create test accounts with required fields
 function createTestAccount(partial: Partial<Account> & { 

--- a/apps/browser-extension/tests/services/keystoreService.test.ts
+++ b/apps/browser-extension/tests/services/keystoreService.test.ts
@@ -1,5 +1,5 @@
 import { KeystoreService } from '../../src/services/keystoreService';
-import type { KeyShareData, ExtensionWalletMetadata, KeystoreBackup } from "@starlab/types/keystore";
+import type { KeyShareData, ExtensionWalletMetadata, KeystoreBackup } from "@stars-labs/types/keystore";
 import { resetStorageData } from '../__mocks__/imports';
 import { resetWxtStorageData } from '../wxt-imports-mock';
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';

--- a/apps/browser-extension/tests/services/networkService.test.ts
+++ b/apps/browser-extension/tests/services/networkService.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 import NetworkService from '../../src/services/networkService';
 import { mainnet, sepolia, polygon, arbitrum } from 'viem/chains';
-import type { Chain } from '@starlab/types/network';
+import type { Chain } from '@stars-labs/types/network';
 
 // Create comprehensive mock for Chrome storage
 const mockStorage = {

--- a/apps/browser-extension/tests/services/wasmService.test.ts
+++ b/apps/browser-extension/tests/services/wasmService.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 // InitWasmReturn was exported from src/lib/wasm-loader pre-
 // monorepo. The loader module was removed when we moved to
-// @starlab/core-wasm; the test uses the type annotation for
+// @stars-labs/core-wasm; the test uses the type annotation for
 // mockInitWasm's return shape, which we can match with `any`.
 type InitWasmReturn = any;
 

--- a/apps/browser-extension/tests/utils/session-parse.test.ts
+++ b/apps/browser-extension/tests/utils/session-parse.test.ts
@@ -18,7 +18,7 @@ import {
     parseSessionInfoFromWire,
     buildWireSessionInfo,
 } from "../../src/utils/session-parse";
-import type { SessionInfo } from "@starlab/types/session";
+import type { SessionInfo } from "@stars-labs/types/session";
 
 describe("parseSessionInfoFromWire", () => {
     it("accepts a minimal TUI-shaped DKG announcement", () => {

--- a/apps/browser-extension/tests/wasm-cli-import.test.ts
+++ b/apps/browser-extension/tests/wasm-cli-import.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeAll } from "bun:test";
 import { readFileSync } from "fs";
 import { join } from "path";
-import init, { FrostDkgSecp256k1, FrostDkgEd25519 } from "@starlab/core-wasm";
+import init, { FrostDkgSecp256k1, FrostDkgEd25519 } from "@stars-labs/core-wasm";
 
 /**
  * Test WASM keystore import functionality with real FROST fixtures.

--- a/apps/browser-extension/tests/wasm-frost-contracts.test.ts
+++ b/apps/browser-extension/tests/wasm-frost-contracts.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, test, expect, beforeAll } from 'bun:test';
-import wasmInit, { FrostDkgEd25519, FrostDkgSecp256k1 } from '@starlab/core-wasm';
+import wasmInit, { FrostDkgEd25519, FrostDkgSecp256k1 } from '@stars-labs/core-wasm';
 
 beforeAll(async () => {
     await wasmInit();

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 0,
   "workspaces": {
     "": {
-      "name": "@starlab/monorepo",
+      "name": "@stars-labs/monorepo",
       "devDependencies": {
         "@solana/web3.js": "^1.98.4",
         "npm-run-all": "^4.1.5",
@@ -11,11 +11,11 @@
       },
     },
     "apps/browser-extension": {
-      "name": "@starlab/browser-extension",
+      "name": "@stars-labs/browser-extension",
       "version": "0.0.0",
       "dependencies": {
-        "@starlab/core-wasm": "workspace:*",
-        "@starlab/types": "workspace:*",
+        "@stars-labs/core-wasm": "workspace:*",
+        "@stars-labs/types": "workspace:*",
         "@tailwindcss/vite": "^4.3.0",
         "tailwindcss": "^4.3.0",
         "uuid": "^14.0.0",
@@ -38,14 +38,14 @@
       },
     },
     "packages/@starlab/core-wasm": {
-      "name": "@starlab/core-wasm",
+      "name": "@stars-labs/core-wasm",
       "version": "0.1.0",
       "devDependencies": {
         "wasm-pack": "^0.13.1",
       },
     },
     "packages/@starlab/types": {
-      "name": "@starlab/types",
+      "name": "@stars-labs/types",
       "version": "0.1.0",
       "devDependencies": {
         "typescript": "^5.8.3",
@@ -147,11 +147,11 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
 
-    "@starlab/browser-extension": ["@starlab/browser-extension@workspace:apps/browser-extension"],
+    "@stars-labs/browser-extension": ["@stars-labs/browser-extension@workspace:apps/browser-extension"],
 
-    "@starlab/core-wasm": ["@starlab/core-wasm@workspace:packages/@starlab/core-wasm"],
+    "@stars-labs/core-wasm": ["@stars-labs/core-wasm@workspace:packages/@starlab/core-wasm"],
 
-    "@starlab/types": ["@starlab/types@workspace:packages/@starlab/types"],
+    "@stars-labs/types": ["@stars-labs/types@workspace:packages/@starlab/types"],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
@@ -1303,7 +1303,7 @@
 
     "@devicefarmer/adbkit/debug": ["debug@4.3.7", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ=="],
 
-    "@starlab/types/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+    "@stars-labs/types/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
     "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,22 +25,22 @@ signing UX. See `git log` for the authoritative record.
 - **Native desktop app** (`apps/native-node/`): Slint 1.x UI reusing
   `starlab-client::core::{*Manager, CoreState}` via a `UICallback` trait.
 - **Shared packages**:
-  - `@starlab/core`: ciphersuite-generic FROST library used
+  - `@stars-labs/core`: ciphersuite-generic FROST library used
     by TUI, native, and (via WASM) the browser extension.
-  - `@starlab/core-wasm`: thin `wasm-bindgen` wrapper.
-  - `@starlab/types`: shared TypeScript types for the extension.
+  - `@stars-labs/core-wasm`: thin `wasm-bindgen` wrapper.
+  - `@stars-labs/types`: shared TypeScript types for the extension.
 - **Build tooling**: Unified Cargo workspace (edition 2024, requires
   Rust 1.85+); Bun workspace for TypeScript packages.
 
 ### Changed
 - **Browser extension**: Moved from repo root to `apps/browser-extension/`.
-- **TypeScript imports**: Standardized on `@starlab/types` package path.
+- **TypeScript imports**: Standardized on `@stars-labs/types` package path.
 - **Build commands**: All `bun run *` scripts run from the repo root.
 - **Nix flake**: Added GUI libs (Wayland, X11, accesskit deps) for Slint.
 
 ### Breaking
 - File paths changed wholesale due to the monorepo restructure.
-- Import statements rewritten to use `@starlab/types`.
+- Import statements rewritten to use `@stars-labs/types`.
 - Build commands must be run from the workspace root, not inside apps.
 
 ## Pre-monorepo milestone — July 2025

--- a/docs/INTEROP_EXT_CLI.md
+++ b/docs/INTEROP_EXT_CLI.md
@@ -20,7 +20,7 @@ This document does two things:
 
 | | Browser extension | CLI (`starlab-cli`) | TUI / native |
 |---|---|---|---|
-| FROST crypto | `@starlab/core-wasm` (Rust→WASM) | `starlab_client` core (Rust) | `starlab_client` core |
+| FROST crypto | `@stars-labs/core-wasm` (Rust→WASM) | `starlab_client` core (Rust) | `starlab_client` core |
 | Same FROST crates? | **yes** (`frost_secp256k1`/`frost_ed25519` via frost-core) | yes | yes |
 | Wire protocol | hand-written TS, modeled on TUI | Rust core | Rust core |
 | Transport | WebSocket (signal) + WebRTC (mesh) | same | same |

--- a/docs/MONOREPO_ARCHITECTURE.md
+++ b/docs/MONOREPO_ARCHITECTURE.md
@@ -55,20 +55,20 @@ starlab-mpc/
 
 ## Shared Packages
 
-### `@starlab/core`
+### `@stars-labs/core`
 Core FROST implementation in Rust, shared between TUI, native, and the WASM bindings:
 - DKG (Distributed Key Generation)
 - Threshold signing
 - Keystore management
 - Multi-curve support (secp256k1, ed25519)
 
-### `@starlab/core-wasm`
+### `@stars-labs/core-wasm`
 Thin WebAssembly wrapper around frost-core:
 - Browser-compatible cryptography
 - Async/await interface
 - TypeScript bindings
 
-### `@starlab/types`
+### `@stars-labs/types`
 Centralized TypeScript type definitions:
 - Message types for all communication
 - State management interfaces
@@ -116,9 +116,9 @@ cargo test                    # Rust tests
 
 ### Development Tips
 
-1. **Shared Types**: Always define types in `@starlab/types`
+1. **Shared Types**: Always define types in `@stars-labs/types`
 2. **Crypto Code**: Implement in `frost-core`, not in apps
-3. **Import Paths**: Use `@starlab/types` not relative paths
+3. **Import Paths**: Use `@stars-labs/types` not relative paths
 4. **Workspace Commands**: Run from root, not subdirectories
 
 ## Architecture Principles
@@ -162,14 +162,14 @@ Browser Extension          TUI Node              Native Node
        |------WebRTC----------|------WebRTC---------|
        
 All apps use the same:
-- Message types (@starlab/types)
-- Cryptography (@starlab/core)
+- Message types (@stars-labs/types)
+- Cryptography (@stars-labs/core)
 - Network protocols
 ```
 
 ## Adding New Features
 
-1. **Define types** in `@starlab/types`
+1. **Define types** in `@stars-labs/types`
 2. **Implement crypto** in `frost-core` if needed
 3. **Add to apps** with platform-specific UI
 4. **Test across platforms** to ensure compatibility
@@ -191,7 +191,7 @@ clarify what the layout can accommodate, not what's under way.
 
 ### Common Issues
 
-1. **Import errors**: Ensure `@starlab/types` is built
+1. **Import errors**: Ensure `@stars-labs/types` is built
 2. **WASM not found**: Run `bun run build:wasm` first
 3. **Type conflicts**: Check for duplicate type definitions
 4. **Build failures**: Clean and rebuild from root

--- a/docs/cli-conformance-testing.md
+++ b/docs/cli-conformance-testing.md
@@ -17,7 +17,7 @@ protocol:
 | TUI node (`apps/tui`) | Rust | `starlab_client::elm` + `starlab_client::core` | Ratatui |
 | Native node (`apps/native-node`) | Rust | reuses `starlab_client::core` + `HeadlessRunner` | Slint |
 | CLI node (`apps/cli`) | Rust | reuses `starlab_client::elm::HeadlessRunner` | JSONL stdin/stdout |
-| Browser extension (`apps/browser-extension`) | TypeScript + WASM | independent reimpl of FROST glue over `@starlab/core-wasm` | Svelte 5 |
+| Browser extension (`apps/browser-extension`) | TypeScript + WASM | independent reimpl of FROST glue over `@stars-labs/core-wasm` | Svelte 5 |
 
 Three of the four (TUI, native, CLI) share the **same Rust Elm core**. The extension is a
 **separate implementation** of the same ceremony, sharing only the FROST primitives (via
@@ -662,7 +662,7 @@ None had any prior test.
 A static check of the extension's independent crypto answered the most important L4
 question without a browser:
 
-- **Address derivation.** The extension's WASM (`@starlab/core-wasm`) derives Ethereum
+- **Address derivation.** The extension's WASM (`@stars-labs/core-wasm`) derives Ethereum
   addresses via `frost-core::Secp256k1Curve::get_eth_address`, which **decompresses the key
   correctly** (`k256::from_sec1_bytes → to_encoded_point(false) → keccak(X‖Y)[12..]`). So
   bug #2 was specific to the divergent `starlab_client::blockchain_config` impl (now fixed to

--- a/docs/implementation/MULTI_LAYER2_SUPPORT.md
+++ b/docs/implementation/MULTI_LAYER2_SUPPORT.md
@@ -9,7 +9,7 @@ Successfully decoupled cryptographic curve selection from specific blockchain ch
 ### 1. Type System Updates (`packages/@starlab/types/src/appstate.ts`)
 
 Note: types were hoisted out of `apps/browser-extension/src/types/` into
-the shared `@starlab/types` package as part of the monorepo
+the shared `@stars-labs/types` package as part of the monorepo
 restructure — earlier drafts of this doc referenced the old
 extension-local path.
 

--- a/docs/testing/COVERAGE.md
+++ b/docs/testing/COVERAGE.md
@@ -28,7 +28,7 @@ Despite configuration attempts, these files cannot be excluded with current Bun 
 Earlier drafts of this section referenced these files at
 `pkg/starlab_mpc.js` and `src/entrypoints/offscreen/test-utils.ts`
 respectively — both paths moved during the monorepo migration
-(WASM bindings live in the shared `@starlab/core-wasm` package;
+(WASM bindings live in the shared `@stars-labs/core-wasm` package;
 test utilities live under the extension's `tests/` tree, not
 `src/`). Historical coverage percentages (45.93% func / 49.02% line
 for the WASM bindings; 69.23% func / 70.59% line for the test

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@starlab/monorepo",
+  "name": "@stars-labs/monorepo",
   "description": "MPC Wallet Monorepo - Multi-Party Computation wallet with FROST signatures",
   "private": true,
   "version": "0.0.0",

--- a/packages/@starlab/core-wasm/package.json
+++ b/packages/@starlab/core-wasm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@starlab/core-wasm",
+  "name": "@stars-labs/core-wasm",
   "version": "0.1.0",
   "description": "FROST MPC WASM bindings for MPC Wallet",
   "type": "module",

--- a/packages/@starlab/types/README.md
+++ b/packages/@starlab/types/README.md
@@ -1,4 +1,4 @@
-# @starlab/types
+# @stars-labs/types
 
 Shared TypeScript type definitions for the MPC Wallet ecosystem.
 
@@ -9,15 +9,15 @@ npm. The monorepo's root `package.json` is marked `"private":
 true` and workspace members consume it via
 
 ```json
-"@starlab/types": "workspace:*"
+"@stars-labs/types": "workspace:*"
 ```
 
 in their own `package.json`, resolved by Bun's workspace
 linker (see `apps/browser-extension/package.json:42` for the
 reference pattern).
 
-Earlier drafts of this README showed `bun add @starlab/types`
-/ `npm install @starlab/types` as install commands; both
+Earlier drafts of this README showed `bun add @stars-labs/types`
+/ `npm install @stars-labs/types` as install commands; both
 would fail for external consumers because the package isn't
 on any registry. To use these types outside the monorepo
 you would need to copy the source or publish a fork yourself.
@@ -27,7 +27,7 @@ you would need to copy the source or publish a fork yourself.
 ### Import specific types
 
 ```typescript
-import { AppState, SessionInfo, DkgState } from '@starlab/types';
+import { AppState, SessionInfo, DkgState } from '@stars-labs/types';
 ```
 
 ### Import message types
@@ -37,7 +37,7 @@ import {
     PopupToBackgroundMessage,
     BackgroundToOffscreenMessage,
     MESSAGE_TYPES 
-} from '@starlab/types';
+} from '@stars-labs/types';
 ```
 
 ### Import constants and utilities
@@ -47,7 +47,7 @@ import {
     INITIAL_APP_STATE,
     MeshStatusType,
     validateSessionProposal 
-} from '@starlab/types';
+} from '@stars-labs/types';
 ```
 
 ## Available Types
@@ -91,7 +91,7 @@ as the re-export aggregator):
 - `webrtc.ts` - WebRTC communication types
   (`WebRTCAppMessage` with `webrtc_msg_type` tag)
 - `websocket.ts` - WebSocket signaling types
-- `index.ts` - re-exports everything for the `@starlab/types`
+- `index.ts` - re-exports everything for the `@stars-labs/types`
   root import (earlier drafts of this list omitted `index.ts`)
 
 ## Development

--- a/packages/@starlab/types/package.json
+++ b/packages/@starlab/types/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@starlab/types",
+  "name": "@stars-labs/types",
   "version": "0.1.0",
   "description": "Shared TypeScript types for the Starlab MPC wallet engine (DKG, sessions, keystore, WebRTC mesh).",
   "license": "MIT OR Apache-2.0",

--- a/packages/@starlab/types/src/appstate.ts
+++ b/packages/@starlab/types/src/appstate.ts
@@ -1,4 +1,4 @@
-// Re-export domain types so existing imports from '@starlab/types/appstate' still work.
+// Re-export domain types so existing imports from '@stars-labs/types/appstate' still work.
 // Canonical definitions live in session.ts, dkg.ts, mesh.ts, and webrtc.ts.
 export type { SessionInfo, SessionProposal, SessionResponse } from './session';
 export { DkgState } from './dkg';

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -6,18 +6,18 @@ set -e
 echo "🔨 Building MPC Wallet Monorepo..."
 
 # Build WASM package first
-echo "📦 Building @starlab/core-wasm..."
+echo "📦 Building @stars-labs/core-wasm..."
 cd packages/@starlab/core-wasm
 bun run build
 cd ../../..
 
 # Build TypeScript types package
-echo "📦 Building @starlab/types..."
+echo "📦 Building @stars-labs/types..."
 cd packages/@starlab/types
 bun run build
 cd ../../..
 
-# Note: `@starlab/utils` used to be listed here but the package
+# Note: `@stars-labs/utils` used to be listed here but the package
 # was never created in the monorepo transform; the previous script
 # would error out at `cd packages/@starlab/utils`.
 


### PR DESCRIPTION
The npm org is **`stars-labs`**, so packages publish under **`@stars-labs`** (there's no `starlab` org). Crates remain `starlab-*` on crates.io — only the npm scope changes.

- npm package names + TS imports + tsconfig paths: `@starlab/*` → `@stars-labs/*`
- **Unchanged:** the `packages/@starlab/` directory and all Rust crate names / Cargo paths (npm-scope-only change)

**Published (public):** `@stars-labs/types@0.1.0`, `@stars-labs/core-wasm@0.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)