### PR TITLE
feat(cli): account model — pinned standard paths, passwordless accounts

### DIFF
--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -123,15 +123,35 @@ enum WalletCmd {
         #[command(flatten)]
         common: OneShot,
     },
+    /// List HD accounts (account 0..N) with their per-chain addresses, using
+    /// the PINNED standard paths (ETH m/44'/60'/0'/0/i, BTC m/84'/0'/0'/0/i,
+    /// SOL m/44'/501'/i'/0', Sui m/44'/784'/i'/0'/0'). Public-key derivation —
+    /// NO password, NO network.
+    Accounts {
+        #[arg(long)]
+        wallet_id: String,
+        /// How many accounts to list (0..count).
+        #[arg(long, default_value_t = 5)]
+        count: u32,
+        #[command(flatten)]
+        common: OneShot,
+    },
     /// Derive a BIP-44-style child wallet (HD) from an existing wallet —
     /// offline, no network. Every participant deriving the SAME path gets the
     /// SAME child key, so a threshold of them can sign for the child address.
     Derive {
         #[arg(long)]
         wallet_id: String,
-        /// Derivation path, e.g. "m/44'/60'/0'/0/1".
+        /// Account index — uses the chain's PINNED standard path. Pair with
+        /// --chain. (The everyday form; --path is the power-user override.)
+        #[arg(long, conflicts_with = "path")]
+        account: Option<u32>,
+        /// Chain for --account: ethereum | bitcoin | solana | sui.
+        #[arg(long, requires = "account")]
+        chain: Option<String>,
+        /// Raw derivation path override, e.g. "m/44'/60'/0'/0/1".
         #[arg(long)]
-        path: String,
+        path: Option<String>,
         /// Persist the child share to the keystore (it then shows up in
         /// `wallet list` and can sign like any wallet).
         #[arg(long)]
@@ -329,11 +349,37 @@ async fn run() -> anyhow::Result<()> {
             WalletCmd::List { common } => {
                 finish(oneshot::wallet_list(common.init_and_opts()).await)
             }
-            WalletCmd::Derive { wallet_id, path, save, pw, common } => {
+            WalletCmd::Accounts { wallet_id, count, common } => {
+                finish(oneshot::wallet_accounts(common.init_and_opts(), wallet_id, count).await)
+            }
+            WalletCmd::Derive { wallet_id, account, chain, path, save, pw, common } => {
                 let password = pw.resolve()?;
+                let (resolved_path, child_suffix) = match (path, account) {
+                    (Some(p), _) => (p, None),
+                    (None, Some(i)) => {
+                        let chain = chain.as_deref().unwrap_or("ethereum");
+                        let p = oneshot::standard_path(chain, i).ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "unknown --chain {chain:?}; expected ethereum|bitcoin|solana|sui"
+                            )
+                        })?;
+                        (p, Some(format!("{chain}-{i}")))
+                    }
+                    (None, None) => anyhow::bail!(
+                        "specify --account <i> [--chain ethereum] for the standard path, \
+                         or --path for a raw override"
+                    ),
+                };
                 finish(
-                    oneshot::wallet_derive(common.init_and_opts(), wallet_id, path, password, save)
-                        .await,
+                    oneshot::wallet_derive(
+                        common.init_and_opts(),
+                        wallet_id,
+                        resolved_path,
+                        child_suffix,
+                        password,
+                        save,
+                    )
+                    .await,
                 )
             }
             WalletCmd::Create {

--- a/apps/cli/src/oneshot.rs
+++ b/apps/cli/src/oneshot.rs
@@ -331,6 +331,22 @@ fn render_human(ev: &CliEvent) -> String {
         } => format!(
             "✔ Reshare complete — group key (and address) unchanged\n  Wallet ID:  {wallet_id}\n  Group key:  {group_public_key}"
         ),
+        CliEvent::Accounts { wallet_id, accounts } => {
+            let mut rows: Vec<Vec<String>> = Vec::new();
+            for a in accounts {
+                for (i, addr) in a.addresses.iter().enumerate() {
+                    rows.push(vec![
+                        if i == 0 { a.account.to_string() } else { String::new() },
+                        addr.chain.clone(),
+                        addr.address.clone(),
+                    ]);
+                }
+            }
+            format!(
+                "Accounts for {wallet_id} (standard paths; derive --account <i> --save to sign)\n\n{}",
+                render_table(&["ACCOUNT", "CHAIN", "ADDRESS"], &rows)
+            )
+        }
         CliEvent::DerivedAddresses {
             wallet_id,
             path,
@@ -635,6 +651,96 @@ pub async fn sign(
     Ok(true)
 }
 
+/// The PINNED standard derivation path per chain (BIP-44/84 coin types).
+/// These are fixed so users only ever think in account indexes — exactly the
+/// BIP-44 contract. Returns None for unknown chains.
+pub fn standard_path(chain: &str, account: u32) -> Option<String> {
+    match chain.to_ascii_lowercase().as_str() {
+        "ethereum" | "eth" => Some(format!("m/44'/60'/0'/0/{account}")),
+        "bitcoin" | "btc" => Some(format!("m/84'/0'/0'/0/{account}")),
+        "solana" | "sol" => Some(format!("m/44'/501'/{account}'/0'")),
+        "sui" => Some(format!("m/44'/784'/{account}'/0'/0'")),
+        _ => None,
+    }
+}
+
+/// `wallet accounts` — list account 0..count with per-chain addresses from
+/// the pinned standard paths. PUBLIC derivation only (the chain code comes
+/// from the group key): no password, no network, safe to run anywhere.
+pub async fn wallet_accounts(
+    opts: OneShotOpts,
+    wallet_id: String,
+    count: u32,
+) -> anyhow::Result<bool> {
+    use starlab_client::keystore::Keystore;
+
+    let ks = Keystore::new(&opts.keystore_path, &opts.device_id)
+        .map_err(|e| anyhow::anyhow!("open keystore {}: {e}", opts.keystore_path))?;
+    let metas: Vec<_> = ks
+        .list_wallets()
+        .into_iter()
+        .filter(|w| w.session_id == wallet_id)
+        .cloned()
+        .collect();
+    if metas.is_empty() {
+        anyhow::bail!(
+            "wallet '{wallet_id}' not found in {} (device {}).",
+            opts.keystore_path,
+            opts.device_id
+        );
+    }
+
+    // (chain display, chain key, curve, group key bytes) for each chain the
+    // wallet's curves control.
+    let mut chains: Vec<(String, String, String, Vec<u8>)> = Vec::new();
+    for meta in &metas {
+        let group = hex::decode(&meta.group_public_key)
+            .map_err(|e| anyhow::anyhow!("bad group key hex: {e}"))?;
+        for (key, display) in crate::bridge::chains_for_curve(&meta.curve_type) {
+            chains.push((
+                (*display).to_string(),
+                (*key).to_string(),
+                meta.curve_type.clone(),
+                group.clone(),
+            ));
+        }
+    }
+
+    let mut accounts: Vec<crate::protocol::AccountEntry> = Vec::new();
+    for i in 0..count {
+        let mut addresses = Vec::new();
+        for (display, key, curve, group) in &chains {
+            let path_s = standard_path(key, i)
+                .ok_or_else(|| anyhow::anyhow!("no standard path for {key}"))?;
+            let path = starlab_core::DerivationPath::parse(&path_s)
+                .map_err(|e| anyhow::anyhow!("parse {path_s}: {e}"))?;
+            let child_pub = match curve.as_str() {
+                "ed25519" => starlab_core::derive_child_verifying_key_path::<
+                    frost_ed25519::Ed25519Sha512,
+                >(group, &path),
+                _ => starlab_core::derive_child_verifying_key_path::<
+                    frost_secp256k1::Secp256K1Sha256,
+                >(group, &path),
+            }
+            .map_err(|e| anyhow::anyhow!("derive {path_s}: {e}"))?;
+            let address = crate::bridge::derive_address(&hex::encode(&child_pub), curve, key);
+            if !address.is_empty() {
+                addresses.push(crate::protocol::ChainAddress {
+                    chain: display.clone(),
+                    address,
+                });
+            }
+        }
+        accounts.push(crate::protocol::AccountEntry { account: i, addresses });
+    }
+
+    print(
+        &CliEvent::Accounts { wallet_id, accounts },
+        opts.json,
+    );
+    Ok(true)
+}
+
 /// Deterministic child wallet id: every participant deriving the same
 /// (parent, path) must land on the same id so co-signing "just works".
 fn child_wallet_id(parent: &str, path: &str) -> String {
@@ -680,6 +786,9 @@ pub async fn wallet_derive(
     opts: OneShotOpts,
     wallet_id: String,
     path: String,
+    // `Some("ethereum-1")` when the path came from --account/--chain — gives
+    // friendlier child ids than the sanitized raw path.
+    child_suffix: Option<String>,
     password: String,
     save: bool,
 ) -> anyhow::Result<bool> {
@@ -705,7 +814,10 @@ pub async fn wallet_derive(
         );
     }
 
-    let child_id = child_wallet_id(&wallet_id, &path);
+    let child_id = match &child_suffix {
+        Some(sfx) => format!("{wallet_id}-{sfx}"),
+        None => child_wallet_id(&wallet_id, &path),
+    };
     let mut addresses: Vec<crate::protocol::ChainAddress> = Vec::new();
     // (curve, child_group_hex, child_blob) per curve, for the optional save.
     let mut children: Vec<(String, String, Vec<u8>)> = Vec::new();

--- a/apps/cli/src/protocol.rs
+++ b/apps/cli/src/protocol.rs
@@ -174,6 +174,12 @@ pub enum CliEvent {
         signature: String,
         message_hash: String,
     },
+    /// HD account listing (reply to `wallet accounts`) — addresses for the
+    /// pinned standard paths, derived from PUBLIC key material only.
+    Accounts {
+        wallet_id: String,
+        accounts: Vec<AccountEntry>,
+    },
     /// HD child addresses derived from a wallet (reply to `wallet derive`).
     DerivedAddresses {
         wallet_id: String,
@@ -191,6 +197,14 @@ pub enum CliEvent {
         code: String,
         message: String,
     },
+}
+
+/// One HD account: a fixed index whose per-chain addresses come from the
+/// pinned standard derivation paths.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct AccountEntry {
+    pub account: u32,
+    pub addresses: Vec<ChainAddress>,
 }
 
 /// One chain's address for a wallet.

--- a/packages/@starlab/core/src/hd_derivation.rs
+++ b/packages/@starlab/core/src/hd_derivation.rs
@@ -380,6 +380,48 @@ pub fn derive_child_key_path<C: Ciphersuite>(
     })
 }
 
+/// PUBLIC-ONLY path derivation: compute a child GROUP VERIFYING KEY from just
+/// the parent group key — no shares, no secrets, no password.
+///
+/// Sound because the per-level offset comes from public material only:
+/// `offset = scalar(HMAC(chain_code, parent_group_key ‖ index))` with the
+/// root chain code itself derived from the group key. This is what lets a
+/// wallet list receive addresses for account 0..N without unlocking
+/// anything; signing for those accounts still requires the (private) share
+/// derivation via [`derive_child_key_path`]. The two are consistent by
+/// construction — pinned by `public_derivation_matches_full_derivation`.
+pub fn derive_child_verifying_key_path<C: Ciphersuite>(
+    group_verifying_key_bytes: &[u8],
+    path: &DerivationPath,
+) -> Result<Vec<u8>> {
+    use frost_core::Group;
+
+    let deserialize = |bytes: &[u8]| -> Result<<C::Group as Group>::Element> {
+        let ser = <C::Group as Group>::Serialization::try_from(bytes.to_vec())
+            .map_err(|_| FrostError::DerivationError("bad group element length".into()))?;
+        <C::Group as Group>::deserialize(&ser)
+            .map_err(|e| FrostError::DerivationError(format!("bad group element: {e}")))
+    };
+    let serialize = |elem: &<C::Group as Group>::Element| -> Result<Vec<u8>> {
+        <C::Group as Group>::serialize(elem)
+            .map(|s| s.as_ref().to_vec())
+            .map_err(|e| FrostError::DerivationError(format!("serialize element: {e}")))
+    };
+
+    let mut current = deserialize(group_verifying_key_bytes)?;
+    let mut chain_code = ChainCode::from_group_key(group_verifying_key_bytes);
+
+    for &index in path.segments() {
+        let parent_bytes = serialize(&current)?;
+        let (scalar_seed, child_cc) = hmac_derive(chain_code.as_bytes(), &parent_bytes, index);
+        let offset = scalar_from_seed::<C>(&scalar_seed)?;
+        let generator = <C::Group as Group>::generator();
+        current = current + generator * offset;
+        chain_code = ChainCode(child_cc);
+    }
+    serialize(&current)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -673,4 +715,37 @@ mod tests {
         // Verify it produces a valid key by checking we can serialize
         let _vk_bytes = derived.public_key_package.verifying_key().serialize().unwrap();
     }
+    #[test]
+    fn public_derivation_matches_full_derivation() {
+        use crate::resharing::dkg_keypackages;
+        use frost_secp256k1::Secp256K1Sha256 as Secp;
+        let (kps, pp) = dkg_keypackages::<Secp>(2, 2, 51).unwrap();
+        let group = pp.verifying_key().serialize().unwrap();
+        let path = DerivationPath::parse("m/44'/60'/0'/0/7").unwrap();
+
+        // Full (share-bearing) derivation
+        let cc = ChainCode::from_group_key(&group);
+        let full = derive_child_key_path::<Secp>(&kps[&1], &pp, &cc, &path).unwrap();
+        let full_group = full.public_key_package.verifying_key().serialize().unwrap();
+
+        // Public-only derivation from just the group key bytes
+        let public_only = derive_child_verifying_key_path::<Secp>(&group, &path).unwrap();
+
+        assert_eq!(public_only, full_group);
+    }
+
+    #[test]
+    fn public_derivation_works_on_ed25519_too() {
+        use crate::resharing::dkg_keypackages;
+        use frost_ed25519::Ed25519Sha512 as Ed;
+        let (kps, pp) = dkg_keypackages::<Ed>(2, 2, 52).unwrap();
+        let group = pp.verifying_key().serialize().unwrap();
+        let path = DerivationPath::parse("m/44'/501'/3'/0'").unwrap();
+        let cc = ChainCode::from_group_key(&group);
+        let full = derive_child_key_path::<Ed>(&kps[&1], &pp, &cc, &path).unwrap();
+        let full_group = full.public_key_package.verifying_key().serialize().unwrap();
+        let public_only = derive_child_verifying_key_path::<Ed>(&group, &path).unwrap();
+        assert_eq!(public_only, full_group);
+    }
+
 }

--- a/packages/@starlab/core/src/lib.rs
+++ b/packages/@starlab/core/src/lib.rs
@@ -26,4 +26,4 @@ pub use secp256k1_tr::Secp256k1TrCurve;
 pub use root_secret::RootSecret;
 pub use unified_dkg::UnifiedDkg;
 pub use resharing::ReshareSession;
-pub use hd_derivation::{ChainCode, DerivationPath, DerivedKeys, derive_child_key, derive_child_key_path};
+pub use hd_derivation::{ChainCode, DerivationPath, DerivedKeys, derive_child_key, derive_child_key_path, derive_child_verifying_key_path};


### PR DESCRIPTION
Implements the user's design call: **BIP-44's contract is that paths are pinned and users think in account indexes** — the wallet model becomes *wallet → accounts*.

**Pinned paths:** ETH `m/44'/60'/0'/0/i` · BTC `m/84'/0'/0'/0/i` · SOL `m/44'/501'/i'/0'` · Sui `m/44'/784'/i'/0'/0'`

```
$ starlab-cli wallet accounts --wallet-id 19caa…        # NO password, NO network
ACCOUNT  CHAIN     ADDRESS
0        Ethereum  0xe31a57e7d27b3ecb642a20eda38b01252cb19df7
         Bitcoin   bc1qc98lcda9j944wwrd7mfxxmgu0nf49j5we9dt00
1        Ethereum  0x3144ff14c1a0957bab793e660837edbe5c8c370c
…
$ starlab-cli wallet derive --wallet-id 19caa… --account 1 --save   # sign-capable child
```

**Why passwordless:** new engine fn `derive_child_verifying_key_path` — public-only derivation (offset + chain code both derive from public material). Parity with the share-bearing derivation pinned by tests on **both curves**, and cross-checked live: the public path reproduces the exact address the private derive produced. `--path` stays as the raw override.

core 35 / cli 44 tests green; golden re-blessed; verified on a real 2-of-3 and the unified 4-chain wallet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)