### PR TITLE
feat(tui): BIP-44 account model — account-0 addresses + accounts table

### DIFF
--- a/apps/tui/src/elm/app.rs
+++ b/apps/tui/src/elm/app.rs
@@ -162,10 +162,26 @@ where
                 )?;
                 self.app.active(&Id::WalletList)?;
             }
-            Screen::WalletDetail { .. } => {
-                self.app.mount(
+            Screen::WalletDetail { ref wallet_id } => {
+                let mut detail = WalletDetail::default();
+                // Hand over every curve entry for this wallet id — the
+                // unified DKG stores the same id once per curve and the
+                // accounts table must cover both curves' chains.
+                let entries: Vec<_> = self
+                    .model
+                    .wallet_state
+                    .wallets
+                    .iter()
+                    .filter(|w| &w.session_id == wallet_id)
+                    .cloned()
+                    .collect();
+                detail.set_wallet(wallet_id.clone(), entries);
+                detail.set_accounts_shown(self.model.ui_state.accounts_shown);
+                // remount, not mount: '+'/'-' trigger a component update
+                // while the screen (and thus the mount) is unchanged.
+                self.app.remount(
                     Id::WalletDetail,
-                    Box::new(WalletDetail::default()),
+                    Box::new(detail),
                     vec![]
                 )?;
                 self.app.active(&Id::WalletDetail)?;
@@ -641,6 +657,10 @@ where
                 | Message::PasswordSubmitDraft
                 | Message::SignTypeChar(_)
                 | Message::SignBackspace
+                // WalletDetail's accounts table derives from
+                // `ui_state.accounts_shown`, read at mount time.
+                | Message::AccountsShowMore
+                | Message::AccountsShowLess
                 // Stage 4: signing-round messages mutate the
                 // acceptance roster on WalletState; the SigningProgress
                 // component reads that roster at mount time, so each
@@ -956,6 +976,23 @@ where
                         });
                     }
                     return None;
+                }
+                _ => return None,
+            }
+        }
+
+        // WalletDetail: '+' / '-' grow/shrink the BIP-44 accounts table.
+        // ('=' is accepted as unshifted '+' on most layouts.) Esc is
+        // handled by the global arm above.
+        if matches!(self.model.current_screen, Screen::WalletDetail { .. }) {
+            match key.code {
+                KeyCode::Char('+') | KeyCode::Char('=') => {
+                    info!("➕ WalletDetail -> AccountsShowMore");
+                    return Some(Message::AccountsShowMore);
+                }
+                KeyCode::Char('-') => {
+                    info!("➖ WalletDetail -> AccountsShowLess");
+                    return Some(Message::AccountsShowLess);
                 }
                 _ => return None,
             }

--- a/apps/tui/src/elm/command.rs
+++ b/apps/tui/src/elm/command.rs
@@ -376,6 +376,25 @@ async fn send_unified_round2<C>(
     }
 }
 
+/// Account 0's `(chain, address)` pairs for one curve's hex group key.
+/// BIP-44 all the way: the UI never shows the raw group-key address — the
+/// root key is a derivation parent only, account 0 is the default identity.
+/// Empty on decode/derivation failure (never fails the completion flow).
+/// Single source of truth: `starlab_core::accounts` (same rows as the CLI).
+fn account0_addresses(curve: &str, group_public_key_hex: &str) -> Vec<(String, String)> {
+    let Ok(group) = hex::decode(group_public_key_hex) else {
+        return Vec::new();
+    };
+    starlab_core::accounts::account_addresses(curve, &group, 0)
+        .map(|entries| {
+            entries
+                .into_iter()
+                .map(|(chain, _path, address)| (chain, address))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// Finalize the unified ceremony: persist both curves and emit `DKGFinalized`
 /// (which the CLI bridge surfaces as `dkg_complete`). Idempotent — `finalize`
 /// returns `None` once the wallet is already written, so calling this from
@@ -407,11 +426,15 @@ async fn try_finalize_unified<C>(
     )
     .await
     {
-        // Both curves' canonical addresses, surfaced to the UI/CLI.
-        let addresses = vec![
-            ("ethereum".to_string(), outcome.eth_address.clone()),
-            ("solana".to_string(), outcome.solana_address.clone()),
-        ];
+        // Both curves' ACCOUNT-0 addresses, surfaced to the UI/CLI. The
+        // outcome's root-key addresses are deliberately not shown — see
+        // `account0_addresses`.
+        let mut addresses =
+            account0_addresses("secp256k1", &outcome.secp256k1_group_public_key);
+        addresses.extend(account0_addresses(
+            "ed25519",
+            &outcome.ed25519_group_public_key,
+        ));
         let _ = tx.send(Message::DKGFinalized {
             wallet_id: outcome.wallet_id,
             // The bridge derives the primary address from this + curve_type;
@@ -2192,11 +2215,10 @@ impl Command {
                     // "unified" literal (see Stage 5 of the plan).
                     let curve_type_str = <C as crate::utils::curve_traits::CurveIdentifier>::curve_type().to_string();
 
-                    let addresses: Vec<(String, String)> = state
-                        .blockchain_addresses
-                        .iter()
-                        .map(|b| (b.blockchain.clone(), b.address.clone()))
-                        .collect();
+                    // ACCOUNT 0's addresses, not the root group-key ones that
+                    // `state.blockchain_addresses` holds — see `account0_addresses`.
+                    let addresses: Vec<(String, String)> =
+                        account0_addresses(&curve_type_str, &hex::encode(&group_pubkey_bytes));
 
                     (
                         state.device_id.clone(),

--- a/apps/tui/src/elm/components/wallet_complete.rs
+++ b/apps/tui/src/elm/components/wallet_complete.rs
@@ -120,11 +120,13 @@ impl Component for WalletCompleteComponent {
         );
 
         // ---- Addresses section ----
+        // BIP-44 all the way: these are ACCOUNT 0's addresses (pinned
+        // standard paths), not the raw group-key address.
         let addr_header = if info.addresses.is_empty() {
-            "Addresses: (none derived for this curve)".to_string()
+            "Account 0 addresses: (none derived for this curve)".to_string()
         } else {
             format!(
-                "Addresses ({} chain{}):",
+                "Account 0 addresses ({} chain{}):",
                 info.addresses.len(),
                 if info.addresses.len() == 1 { "" } else { "s" }
             )

--- a/apps/tui/src/elm/components/wallet_detail.rs
+++ b/apps/tui/src/elm/components/wallet_detail.rs
@@ -1,64 +1,211 @@
-//! Wallet Detail Component - Shows detailed wallet information
+//! Wallet Detail Component — wallet metadata + the BIP-44 ACCOUNTS table.
+//!
+//! "BIP-44 all the way": the root group key is a derivation parent only —
+//! it is never rendered as a wallet address. This screen shows the account
+//! table instead (account index × chain × address), derived public-only via
+//! `starlab_core::accounts` — the shared single source of truth, so every
+//! row matches the CLI's `wallet accounts` byte-for-byte.
+//!
+//! Keyboard routing is owned by `app.rs::handle_key_event` (same pattern as
+//! `wallet_complete.rs`): '+' / '-' fire `Message::AccountsShowMore/Less`,
+//! which mutate `Model.ui_state.accounts_shown`; the remount pushes the new
+//! count back in through `set_accounts_shown`.
 
 use crate::elm::components::{Id, UserEvent, MpcWalletComponent};
 use crate::elm::message::Message;
+use crate::keystore::WalletMetadata;
 use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::Event;
 use tuirealm::ratatui::Frame;
 use tuirealm::props::Props;
 use tuirealm::state::State;
 use tuirealm::command::{Cmd, CmdResult};
-use ratatui::layout::Rect;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
 
-#[derive(Debug, Clone, Default)]
+/// How many accounts (0..n) the table shows before the user presses '+'.
+pub const DEFAULT_ACCOUNTS_SHOWN: u32 = 5;
+
+#[derive(Debug, Clone)]
 pub struct WalletDetail {
     props: Props,
     wallet_id: Option<String>,
+    /// Every curve entry the keystore holds for this wallet id — the
+    /// unified DKG persists the same id under ed25519/ AND secp256k1/,
+    /// and the accounts table must cover both curves' chains.
+    entries: Vec<WalletMetadata>,
+    /// How many accounts (0..n) to derive rows for.
+    accounts_shown: u32,
     focused: bool,
 }
 
-impl WalletDetail {
-    pub fn with_wallet_id(wallet_id: String) -> Self {
+impl Default for WalletDetail {
+    fn default() -> Self {
         Self {
             props: Props::default(),
-            wallet_id: Some(wallet_id),
+            wallet_id: None,
+            entries: Vec::new(),
+            accounts_shown: DEFAULT_ACCOUNTS_SHOWN,
             focused: false,
         }
     }
 }
 
+impl WalletDetail {
+    /// Called from `app.rs::mount_components` — hands over the wallet id
+    /// plus all of its curve entries from `Model.wallet_state.wallets`.
+    pub fn set_wallet(&mut self, wallet_id: String, entries: Vec<WalletMetadata>) {
+        self.wallet_id = Some(wallet_id);
+        self.entries = entries;
+    }
+
+    /// Sync the account count from `Model.ui_state.accounts_shown` at
+    /// mount time ('+' / '-' mutate the model, the remount lands here).
+    pub fn set_accounts_shown(&mut self, n: u32) {
+        self.accounts_shown = n.max(1);
+    }
+
+    /// Derive the table rows: `(account, chain, path, address)` for
+    /// accounts `0..accounts_shown` across every curve entry. Public-only
+    /// derivation — no key share, no password. Undecodable/underivable
+    /// entries are skipped rather than failing the whole screen.
+    fn account_rows(&self) -> Vec<[String; 4]> {
+        let mut rows = Vec::new();
+        for account in 0..self.accounts_shown {
+            for w in &self.entries {
+                let Ok(group) = hex::decode(&w.group_public_key) else {
+                    continue;
+                };
+                let Ok(addrs) =
+                    starlab_core::accounts::account_addresses(&w.curve_type, &group, account)
+                else {
+                    continue;
+                };
+                for (chain, path, address) in addrs {
+                    rows.push([account.to_string(), chain, path, address]);
+                }
+            }
+        }
+        rows
+    }
+}
+
 impl Component for WalletDetail {
     fn view(&mut self, frame: &mut Frame, area: Rect) {
-        use ratatui::widgets::{Block, Borders, Paragraph};
-        use ratatui::style::{Color, Style};
-        
-        let wallet_info = if let Some(ref id) = self.wallet_id {
-            format!("Wallet Details\nID: {}", id)
-        } else {
-            "No wallet selected".to_string()
+        use ratatui::style::{Color, Modifier, Style};
+        use ratatui::widgets::{Block, BorderType, Borders, Cell, Paragraph, Row, Table};
+
+        let title = match self.wallet_id.as_deref() {
+            Some(id) => format!(" Wallet — {} ", id),
+            None => " Wallet Detail ".to_string(),
         };
-        
-        let widget = Paragraph::new(wallet_info)
-            .block(Block::default()
-                .title("Wallet Detail")
+        let outer = Block::default()
+            .title(title)
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(if self.focused {
+                Style::default().fg(Color::Cyan)
+            } else {
+                Style::default().fg(Color::Gray)
+            });
+        let inner = outer.inner(area);
+        frame.render_widget(outer, area);
+
+        if self.entries.is_empty() {
+            let p = Paragraph::new("Wallet not found in keystore.")
+                .style(Style::default().fg(Color::Red));
+            frame.render_widget(p, inner);
+            return;
+        }
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .margin(1)
+            .constraints([
+                Constraint::Length(2), // wallet metadata summary
+                Constraint::Min(3),    // accounts table (grows)
+                Constraint::Length(1), // hints
+            ])
+            .split(inner);
+
+        // ---- Metadata summary (no root address — BIP-44 all the way) ----
+        let w0 = &self.entries[0];
+        let mut curves: Vec<&str> = self.entries.iter().map(|w| w.curve_type.as_str()).collect();
+        curves.sort_unstable();
+        let summary = format!(
+            "Name: {}\nThreshold: {}/{}  Curves: {}  Created: {}",
+            w0.display_name(),
+            w0.threshold,
+            w0.total_participants,
+            curves.join("+"),
+            w0.created_at.split('T').next().unwrap_or(&w0.created_at),
+        );
+        frame.render_widget(
+            Paragraph::new(summary).style(Style::default().fg(Color::Gray)),
+            chunks[0],
+        );
+
+        // ---- Accounts table ----
+        let header = Row::new(vec![
+            Cell::from("Acct"),
+            Cell::from("Chain"),
+            Cell::from("Path"),
+            Cell::from("Address"),
+        ])
+        .style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        );
+        let rows: Vec<Row> = self
+            .account_rows()
+            .into_iter()
+            .map(|[account, chain, path, address]| {
+                Row::new(vec![
+                    Cell::from(account),
+                    Cell::from(chain),
+                    Cell::from(path),
+                    Cell::from(address),
+                ])
+                .style(Style::default().fg(Color::White))
+            })
+            .collect();
+        let table = Table::new(
+            rows,
+            [
+                Constraint::Length(4),
+                Constraint::Length(10),
+                Constraint::Length(20),
+                Constraint::Min(20),
+            ],
+        )
+        .header(header)
+        .block(
+            Block::default()
+                .title(format!("Accounts (0..{})", self.accounts_shown - 1))
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::Gray)));
-        
-        frame.render_widget(widget, area);
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(Color::DarkGray)),
+        );
+        frame.render_widget(table, chunks[1]);
+
+        // ---- Hints row ----
+        let hints = Paragraph::new("+ = more accounts    - = fewer    Esc = Back")
+            .style(Style::default().fg(Color::DarkGray));
+        frame.render_widget(hints, chunks[2]);
     }
-    
+
     fn query<'a>(&'a self, attr: tuirealm::props::Attribute) -> Option<tuirealm::props::QueryResult<'a>> {
         self.props.get_for_query(attr)
     }
-    
+
     fn attr(&mut self, attr: tuirealm::props::Attribute, value: tuirealm::props::AttrValue) {
         self.props.set(attr, value);
     }
-    
+
     fn state(&self) -> State {
         State::None
     }
-    
+
     fn perform(&mut self, _cmd: Cmd) -> CmdResult {
         CmdResult::NoChange
     }
@@ -74,12 +221,62 @@ impl MpcWalletComponent for WalletDetail {
     fn id(&self) -> Id {
         Id::WalletDetail
     }
-    
+
     fn is_visible(&self) -> bool {
         true
     }
-    
+
     fn on_focus(&mut self, focused: bool) {
         self.focused = focused;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn meta(curve: &str, group_hex: &str) -> WalletMetadata {
+        WalletMetadata::new(
+            "w1".to_string(),
+            "d1".to_string(),
+            curve.to_string(),
+            2,
+            3,
+            1,
+            group_hex.to_string(),
+        )
+    }
+
+    /// A valid compressed secp256k1 point (the generator).
+    const SECP_G: &str = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+    #[test]
+    fn account_rows_cover_each_account_and_chain() {
+        let mut c = WalletDetail::default();
+        c.set_wallet("w1".to_string(), vec![meta("secp256k1", SECP_G)]);
+        c.set_accounts_shown(2);
+        let rows = c.account_rows();
+        // 2 accounts × 2 secp chains (Ethereum, Bitcoin)
+        assert_eq!(rows.len(), 4);
+        assert_eq!(rows[0][0], "0");
+        assert_eq!(rows[0][1], "Ethereum");
+        assert!(rows[0][3].starts_with("0x"));
+        assert_eq!(rows[3][0], "1");
+        assert_eq!(rows[3][1], "Bitcoin");
+        assert!(rows[3][3].starts_with("bc1"));
+    }
+
+    #[test]
+    fn account_rows_skip_undecodable_group_keys() {
+        let mut c = WalletDetail::default();
+        c.set_wallet("w1".to_string(), vec![meta("secp256k1", "not-hex")]);
+        assert!(c.account_rows().is_empty());
+    }
+
+    #[test]
+    fn accounts_shown_floors_at_one() {
+        let mut c = WalletDetail::default();
+        c.set_accounts_shown(0);
+        assert_eq!(c.accounts_shown, 1);
     }
 }

--- a/apps/tui/src/elm/components/wallet_list.rs
+++ b/apps/tui/src/elm/components/wallet_list.rs
@@ -221,8 +221,20 @@ impl Component for WalletList {
             let details = [format!("Created: {}", wallet.created_at),
                 format!("Device: {}", wallet.device_id),
                 format!("Index: {}/{}", wallet.participant_index, wallet.total_participants)];
-            
-            let details_text = details.join(" | ");
+
+            // BIP-44 all the way: the displayed address is ACCOUNT 0's
+            // primary chain address (pinned standard path), never the raw
+            // group-key address — the root key is a derivation parent only.
+            let account0 = hex::decode(&wallet.group_public_key)
+                .ok()
+                .and_then(|group| {
+                    starlab_core::accounts::account_addresses(&wallet.curve_type, &group, 0).ok()
+                })
+                .and_then(|addrs| addrs.into_iter().next())
+                .map(|(chain, _path, address)| format!("Account 0 ({}): {}", chain, address))
+                .unwrap_or_else(|| "Account 0: (underivable)".to_string());
+
+            let details_text = format!("{}\n{}", details.join(" | "), account0);
             
             let details_widget = Paragraph::new(details_text)
                 .block(

--- a/apps/tui/src/elm/message.rs
+++ b/apps/tui/src/elm/message.rs
@@ -85,6 +85,11 @@ pub enum Message {
     WalletExported { wallet_id: String, path: String },
     ImportWallet { data: Vec<u8> },
     WalletImported { wallet_id: String },
+    /// '+' on the WalletDetail screen — derive one more BIP-44 account
+    /// row in the accounts table (`Model.ui_state.accounts_shown`).
+    AccountsShowMore,
+    /// '-' on the WalletDetail screen — show one fewer account (floors at 1).
+    AccountsShowLess,
     
     // Wallet creation flow
     SelectMode(WalletMode),

--- a/apps/tui/src/elm/model.rs
+++ b/apps/tui/src/elm/model.rs
@@ -401,6 +401,11 @@ pub struct UIState {
     pub is_busy: bool,
     pub progress: Option<ProgressInfo>,
     pub join_session_tab: usize, // 0 = DKG, 1 = Signing
+    /// How many BIP-44 accounts the WalletDetail accounts table derives
+    /// (0..n). '+' / '-' on that screen adjust it; reset to the default
+    /// whenever a wallet is selected so the table doesn't carry one
+    /// wallet's expansion over to the next.
+    pub accounts_shown: u32,
 }
 
 impl Default for UIState {
@@ -417,6 +422,7 @@ impl Default for UIState {
             is_busy: false,
             progress: None,
             join_session_tab: 0, // Default to DKG tab
+            accounts_shown: crate::elm::components::wallet_detail::DEFAULT_ACCOUNTS_SHOWN,
         }
     }
 }

--- a/apps/tui/src/elm/update.rs
+++ b/apps/tui/src/elm/update.rs
@@ -758,12 +758,28 @@ pub fn update(model: &mut Model, msg: Message) -> Option<Command> {
         Message::SelectWallet { wallet_id } => {
             info!("Selected wallet: {}", wallet_id);
             model.selected_wallet = Some(wallet_id.clone());
-            
+            // Fresh wallet → fresh accounts-table depth.
+            model.ui_state.accounts_shown =
+                crate::elm::components::wallet_detail::DEFAULT_ACCOUNTS_SHOWN;
+
             // Navigate to wallet detail
             model.push_screen(Screen::WalletDetail { wallet_id: wallet_id.clone() });
-            
+
             // Load wallet details
             Some(Command::LoadWalletDetails { wallet_id })
+        }
+
+        // '+' / '-' on the WalletDetail screen: grow/shrink the BIP-44
+        // accounts table. The component re-reads `accounts_shown` at
+        // remount (app.rs marks these as needs_component_update).
+        Message::AccountsShowMore => {
+            model.ui_state.accounts_shown = model.ui_state.accounts_shown.saturating_add(1);
+            None
+        }
+
+        Message::AccountsShowLess => {
+            model.ui_state.accounts_shown = model.ui_state.accounts_shown.saturating_sub(1).max(1);
+            None
         }
         
         Message::ListWallets => {
@@ -1272,7 +1288,15 @@ pub fn update(model: &mut Model, msg: Message) -> Option<Command> {
         Message::WalletsLoaded { wallets } => {
             info!("Loaded {} wallets", wallets.len());
             let old_count = model.wallet_state.wallets.len();
-            model.wallet_state.wallets = wallets;
+            // Materialized HD account children carry their derivation path
+            // as the label ("m/44'/…"). They're an implementation detail of
+            // signing — listing them would double-derive (account 0 OF an
+            // account) and clutter the wallet view. Same filter as the CLI
+            // bridge's wallet_entries; the accounts table is their UI.
+            model.wallet_state.wallets = wallets
+                .into_iter()
+                .filter(|w| !w.label.as_deref().is_some_and(|l| l.starts_with("m/")))
+                .collect();
             
             // If on main menu and wallet count changed, force remount to update menu
             if matches!(model.current_screen, Screen::MainMenu | Screen::Welcome) && 
@@ -3365,5 +3389,63 @@ mod tests {
         // Modal should be closed, no navigation
         assert!(model.ui_state.modal.is_none());
         assert!(cmd.is_none());
+    }
+
+    #[test]
+    fn wallets_loaded_hides_materialized_account_children() {
+        let mut model = Model::new("test".to_string());
+        let mut root = crate::keystore::WalletMetadata::new(
+            "w1".to_string(),
+            "d1".to_string(),
+            "secp256k1".to_string(),
+            2,
+            3,
+            1,
+            "00".to_string(),
+        );
+        root.label = Some("My Wallet".to_string());
+        let mut child = root.clone();
+        child.session_id = "w1-child".to_string();
+        child.label = Some("m/44'/60'/0'/0/0".to_string());
+
+        update(&mut model, Message::WalletsLoaded { wallets: vec![root, child] });
+
+        assert_eq!(
+            model.wallet_state.wallets.len(),
+            1,
+            "m/-labeled HD children must not appear in the wallet list"
+        );
+        assert_eq!(model.wallet_state.wallets[0].session_id, "w1");
+    }
+
+    #[test]
+    fn accounts_show_more_and_less_adjust_with_floor_of_one() {
+        let mut model = Model::new("test".to_string());
+        let start = model.ui_state.accounts_shown;
+
+        update(&mut model, Message::AccountsShowMore);
+        assert_eq!(model.ui_state.accounts_shown, start + 1);
+
+        for _ in 0..(start + 5) {
+            update(&mut model, Message::AccountsShowLess);
+        }
+        assert_eq!(model.ui_state.accounts_shown, 1, "must floor at one account");
+    }
+
+    #[test]
+    fn select_wallet_resets_accounts_shown_to_default() {
+        let mut model = Model::new("test".to_string());
+        model.ui_state.accounts_shown = 12;
+
+        update(&mut model, Message::SelectWallet { wallet_id: "w1".to_string() });
+
+        assert_eq!(
+            model.ui_state.accounts_shown,
+            crate::elm::components::wallet_detail::DEFAULT_ACCOUNTS_SHOWN
+        );
+        assert!(matches!(
+            model.current_screen,
+            Screen::WalletDetail { ref wallet_id } if wallet_id == "w1"
+        ));
     }
 }


### PR DESCRIPTION
"BIP-44 all the way" in the ratatui TUI, mirroring the CLI bridge: the root group-key address is never displayed; account 0 is the default identity, derived via `starlab_core::accounts` — so every address matches the CLI byte-for-byte.

## What changed

- **WalletDetail is now a real screen**: wallet metadata summary + an ACCOUNTS table (account × chain × path × address) covering both curves of a unified wallet. `+` derives one more account, `-` one fewer (floor 1); depth lives on `Model.ui_state.accounts_shown` and resets per wallet selection.
- **WalletList** details panel shows account 0's primary address (public-only derivation — no password needed).
- **WalletComplete** (post-DKG) lists ACCOUNT 0's addresses on both the unified and single-curve finalize paths via the new `account0_addresses` helper, instead of the root group-key addresses.
- **WalletsLoaded** filters out materialized HD account children (label starting `m/`) exactly like the CLI's `wallet_entries` — they're a signing implementation detail; the accounts table is their UI.

Tests: component-level `account_rows` coverage + update-layer tests (m/ filter, ± depth, per-wallet reset). Full `cargo test -p starlab-client`: 111 + 13 + 88 passed.

Completes the account-model rollout: CLI (#100) ✅ extension (starlab-wallet #59) ✅ desktop (starlab-desktop #4) ✅ TUI (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)