### PR TITLE
fix(cli): show the BIP-44 derivation path in wallet list / accounts output

### DIFF
--- a/apps/cli/src/bridge.rs
+++ b/apps/cli/src/bridge.rs
@@ -326,10 +326,11 @@ fn wallet_entries(wallets: &[WalletMetadata]) -> Vec<WalletEntry> {
                 if let Ok(entries) =
                     starlab_core::accounts::account_addresses(&w.curve_type, &group, 0)
                 {
-                    for (display, _path, address) in entries {
+                    for (display, path, address) in entries {
                         e.addresses.push(crate::protocol::ChainAddress {
                             chain: display,
                             address,
+                            path: Some(path),
                         });
                     }
                 }

--- a/apps/cli/src/oneshot.rs
+++ b/apps/cli/src/oneshot.rs
@@ -263,10 +263,12 @@ fn render_human(ev: &CliEvent) -> String {
                         w.threshold.clone(),
                         w.chain.clone(),
                         w.address.clone(),
+                        "-".to_string(),
                     ]);
                     continue;
                 }
                 for (i, a) in w.addresses.iter().enumerate() {
+                    let path = a.path.clone().unwrap_or_else(|| "-".to_string());
                     if i == 0 {
                         rows.push(vec![
                             w.id.clone(),
@@ -274,6 +276,7 @@ fn render_human(ev: &CliEvent) -> String {
                             w.threshold.clone(),
                             a.chain.clone(),
                             a.address.clone(),
+                            path,
                         ]);
                     } else {
                         rows.push(vec![
@@ -282,11 +285,12 @@ fn render_human(ev: &CliEvent) -> String {
                             String::new(),
                             a.chain.clone(),
                             a.address.clone(),
+                            path,
                         ]);
                     }
                 }
             }
-            render_table(&["ID", "NAME", "QUORUM", "CHAIN", "ADDRESS"], &rows)
+            render_table(&["ID", "NAME", "QUORUM", "CHAIN", "ADDRESS", "PATH"], &rows)
         }
         CliEvent::Sessions { sessions } => {
             if sessions.is_empty() {
@@ -339,12 +343,13 @@ fn render_human(ev: &CliEvent) -> String {
                         if i == 0 { a.account.to_string() } else { String::new() },
                         addr.chain.clone(),
                         addr.address.clone(),
+                        addr.path.clone().unwrap_or_else(|| "-".to_string()),
                     ]);
                 }
             }
             format!(
                 "Accounts for {wallet_id} (standard paths; derive --account <i> --save to sign)\n\n{}",
-                render_table(&["ACCOUNT", "CHAIN", "ADDRESS"], &rows)
+                render_table(&["ACCOUNT", "CHAIN", "ADDRESS", "PATH"], &rows)
             )
         }
         CliEvent::DerivedAddresses {
@@ -812,6 +817,7 @@ pub async fn wallet_accounts(
                 addresses.push(crate::protocol::ChainAddress {
                     chain: display.clone(),
                     address,
+                    path: Some(path_s.clone()),
                 });
             }
         }
@@ -923,6 +929,7 @@ pub async fn wallet_derive(
                 addresses.push(crate::protocol::ChainAddress {
                     chain: (*display).to_string(),
                     address,
+                    path: Some(path.clone()),
                 });
             }
         }

--- a/apps/cli/src/protocol.rs
+++ b/apps/cli/src/protocol.rs
@@ -212,6 +212,10 @@ pub struct AccountEntry {
 pub struct ChainAddress {
     pub chain: String,
     pub address: String,
+    /// BIP-44 derivation path the address came from (pinned standard paths;
+    /// `None` only for legacy emitters that predate the account model).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
 }
 
 /// UI-facing wallet summary (never leaks internal crypto types).


### PR DESCRIPTION
User-reported: `wallet list` shows account-0 addresses (BIP-44 cutover) but nothing in the output says so — "没有体现BIP44?".

- `ChainAddress` gains optional `path` (`skip_serializing_if = None` — old JSON consumers unaffected), populated at every derivation site (bridge wallet list, `wallet accounts`, `wallet derive`).
- `wallet list` and `wallet accounts` human tables grow a PATH column:

```
ID            NAME  QUORUM  CHAIN     ADDRESS                                     PATH
19caa3cf46d3  -     2/3     Ethereum  0xe31a57e7d27b3ecb642a20eda38b01252cb19df7  m/44'/60'/0'/0/0
                            Bitcoin   bc1qc98lcda9j944wwrd7mfxxmgu0nf49j5we9dt00  m/84'/0'/0'/0/0
```

Verified live against the real 2/3 keystore (output above). Full `cargo test -p starlab-cli` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)