### PR TITLE
fix(signing): BIP-44 account signing everywhere — co-signer auto-materialize + TUI never signs root

### DIFF
--- a/apps/cli/src/oneshot.rs
+++ b/apps/cli/src/oneshot.rs
@@ -624,11 +624,12 @@ pub async fn reshare(
     Ok(true)
 }
 
-/// `sign` — initiate a threshold signing and block until it completes.
 /// Materialize (derive + persist) the HD account child wallet if it isn't in
-/// the keystore yet. Deterministic — every participant materializing the same
-/// (parent, chain, account) lands on the same child id and key. Returns the
-/// child wallet id to sign with.
+/// the keystore yet. Thin keystore-opening wrapper over the SHARED
+/// implementation in `starlab_client::elm::command::ensure_account_wallet`
+/// (the same one the elm co-signer unlock path uses), so the CLI and every
+/// elm-driven client agree on the child id + label byte-for-byte. Returns
+/// the child wallet id to sign with.
 fn ensure_account_wallet(
     opts: &OneShotOpts,
     parent_id: &str,
@@ -640,64 +641,13 @@ fn ensure_account_wallet(
 
     let mut ks = Keystore::new(&opts.keystore_path, &opts.device_id)
         .map_err(|e| anyhow::anyhow!("open keystore {}: {e}", opts.keystore_path))?;
-    let metas: Vec<_> = ks
-        .list_wallets()
-        .into_iter()
-        .filter(|w| w.session_id == parent_id)
-        .cloned()
-        .collect();
-    if metas.is_empty() {
-        anyhow::bail!("wallet '{parent_id}' not found (device {}).", opts.device_id);
-    }
-
-    // Default chain: the primary chain of the wallet's curve(s).
-    let has_secp = metas.iter().any(|m| m.curve_type == "secp256k1");
-    let chain = chain
-        .map(str::to_string)
-        .unwrap_or_else(|| if has_secp { "ethereum".into() } else { "solana".into() });
-    let path_s = standard_path(&chain, account)
-        .ok_or_else(|| anyhow::anyhow!("unknown --chain {chain:?}"))?;
-    let curve = if matches!(chain.as_str(), "solana" | "sol" | "sui") {
-        "ed25519"
-    } else {
-        "secp256k1"
-    };
-    let meta = metas
-        .iter()
-        .find(|m| m.curve_type == curve)
-        .ok_or_else(|| anyhow::anyhow!("wallet '{parent_id}' has no {curve} share for {chain}"))?;
-
-    let child_id = format!("{parent_id}-{chain}-{account}");
-    if ks.get_wallet(&child_id).is_some() {
-        return Ok(child_id);
-    }
-
-    let parsed = starlab_core::DerivationPath::parse(&path_s)
-        .map_err(|e| anyhow::anyhow!("parse {path_s}: {e}"))?;
-    let blob = ks
-        .load_wallet_file_for_curve(parent_id, curve, password)
-        .map_err(|e| anyhow::anyhow!("unlock '{parent_id}' ({curve}): {e}"))?;
-    let (child_blob, child_group_hex) = match curve {
-        "ed25519" => derive_child_for_curve::<frost_ed25519::Ed25519Sha512>(&blob, &parsed)?,
-        _ => derive_child_for_curve::<frost_secp256k1::Secp256K1Sha256>(&blob, &parsed)?,
-    };
-    ks.create_wallet_multi_chain(
-        &child_id,
-        curve,
-        vec![],
-        meta.threshold,
-        meta.total_participants,
-        &child_group_hex,
-        &child_blob,
-        password,
-        vec![],
-        None,
-        meta.participant_index,
-        meta.participants.clone(),
-        Some(path_s),
+    let (child_id, materialized) = starlab_client::elm::command::ensure_account_wallet(
+        &mut ks, parent_id, account, chain, password,
     )
-    .map_err(|e| anyhow::anyhow!("materialize account wallet: {e}"))?;
-    eprintln!("note: materialized account wallet '{child_id}' (deterministic — co-signers do the same on first use)");
+    .map_err(|e| anyhow::anyhow!("{e} (device {})", opts.device_id))?;
+    if materialized {
+        eprintln!("note: materialized account wallet '{child_id}' (deterministic — co-signers do the same on first use)");
+    }
     Ok(child_id)
 }
 
@@ -711,17 +661,15 @@ pub async fn sign(
     password: String,
 ) -> anyhow::Result<bool> {
     // BIP-44 all the way: signing happens with the ACCOUNT key, never the
-    // root. If the caller passed an already-materialized child id (contains
-    // the "-<chain>-<n>" suffix), use it as-is; otherwise materialize
+    // root. If the caller passed an already-materialized child id
+    // (`{parent}-{chain}-{n}`), use it as-is; otherwise materialize
     // account `account` of the given parent on demand.
-    let signing_wallet_id = {
-        let ks_has_it_as_is = wallet_id.rsplit('-').next().and_then(|s| s.parse::<u32>().ok());
-        if ks_has_it_as_is.is_some() && wallet_id.matches('-').count() >= 2 {
+    let signing_wallet_id =
+        if starlab_core::accounts::parse_child_wallet_id(&wallet_id).is_some() {
             wallet_id.clone()
         } else {
             ensure_account_wallet(&opts, &wallet_id, account, chain.as_deref(), &password)?
-        }
-    };
+        };
     let (tx, mut rx, roster) = start(&opts);
     tx.send(Message::TriggerReconnect)?;
     wait_connected(&mut rx, &opts).await?;
@@ -843,28 +791,14 @@ fn child_wallet_id(parent: &str, path: &str) -> String {
 
 /// Derive a child (key share + group key) for one curve from a decrypted
 /// keystore blob. Returns (child blob, child group public key hex).
+/// Anyhow-flavored shim over the SHARED implementation in
+/// `starlab_client::elm::command` (one derivation for every client).
 fn derive_child_for_curve<C: frost_core::Ciphersuite>(
     blob: &[u8],
     path: &starlab_core::DerivationPath,
 ) -> anyhow::Result<(Vec<u8>, String)> {
-    use starlab_client::elm::command::{decode_keystore_blob, encode_keystore_blob};
-    let (kp, pp) = decode_keystore_blob::<C>(blob)
-        .map_err(|e| anyhow::anyhow!("decode key share: {e}"))?;
-    let group = pp
-        .verifying_key()
-        .serialize()
-        .map_err(|e| anyhow::anyhow!("serialize group key: {e}"))?;
-    let chain_code = starlab_core::ChainCode::from_group_key(group.as_ref());
-    let derived = starlab_core::derive_child_key_path::<C>(&kp, &pp, &chain_code, path)
-        .map_err(|e| anyhow::anyhow!("derive: {e}"))?;
-    let child_group = derived
-        .public_key_package
-        .verifying_key()
-        .serialize()
-        .map_err(|e| anyhow::anyhow!("serialize child group key: {e}"))?;
-    let child_blob = encode_keystore_blob::<C>(&derived.key_package, &derived.public_key_package)
-        .map_err(|e| anyhow::anyhow!("encode child share: {e}"))?;
-    Ok((child_blob, hex::encode(child_group)))
+    starlab_client::elm::command::derive_child_for_curve::<C>(blob, path)
+        .map_err(|e| anyhow::anyhow!(e))
 }
 
 /// `wallet derive` — BIP-44-style HD child derivation. Fully offline: reads

--- a/apps/tui/src/elm/command.rs
+++ b/apps/tui/src/elm/command.rs
@@ -276,6 +276,144 @@ pub fn decode_keystore_blob<C: frost_core::Ciphersuite>(
     Ok((kp, pkp))
 }
 
+/// Derive a child (key share + group key) for one curve from a decrypted
+/// keystore blob. Returns (child blob, child group public key hex).
+/// Deterministic across participants — the chain code comes from the group
+/// key — so a threshold of co-signers deriving the SAME path can sign for
+/// the child address.
+pub fn derive_child_for_curve<C: frost_core::Ciphersuite>(
+    blob: &[u8],
+    path: &starlab_core::DerivationPath,
+) -> Result<(Vec<u8>, String), String> {
+    let (kp, pp) = decode_keystore_blob::<C>(blob)
+        .map_err(|e| format!("decode key share: {e}"))?;
+    let group = pp
+        .verifying_key()
+        .serialize()
+        .map_err(|e| format!("serialize group key: {e:?}"))?;
+    let chain_code = starlab_core::ChainCode::from_group_key(group.as_ref());
+    let derived = starlab_core::derive_child_key_path::<C>(&kp, &pp, &chain_code, path)
+        .map_err(|e| format!("derive: {e}"))?;
+    let child_group = derived
+        .public_key_package
+        .verifying_key()
+        .serialize()
+        .map_err(|e| format!("serialize child group key: {e:?}"))?;
+    let child_blob = encode_keystore_blob::<C>(&derived.key_package, &derived.public_key_package)
+        .map_err(|e| format!("encode child share: {e}"))?;
+    Ok((child_blob, hex::encode(child_group)))
+}
+
+/// Materialize (derive + persist) the HD account child wallet
+/// `{parent}-{chain}-{account}` if it isn't in the keystore yet — "BIP-44
+/// all the way": signing always happens with an ACCOUNT key, never the
+/// root. Deterministic: every participant materializing the same
+/// (parent, chain, account) lands on the same child id and key, so
+/// co-signing "just works" with no pre-derive step.
+///
+/// The child id is EXACTLY `{parent}-{chain}-{account}` and the label is
+/// EXACTLY the derivation path (wallet-list filters key off
+/// `label.starts_with("m/")`). Shared by the CLI one-shot `sign`, the elm
+/// co-signer unlock path, and TUI-initiated signing — ONE implementation.
+///
+/// Returns `(child wallet id to sign with, whether it was materialized
+/// just now — false when it was already in the keystore)`.
+pub fn ensure_account_wallet(
+    ks: &mut crate::keystore::Keystore,
+    parent_id: &str,
+    account: u32,
+    chain: Option<&str>,
+    password: &str,
+) -> Result<(String, bool), String> {
+    let metas: Vec<crate::keystore::WalletMetadata> = ks
+        .list_wallets()
+        .into_iter()
+        .filter(|w| w.session_id == parent_id)
+        .cloned()
+        .collect();
+    if metas.is_empty() {
+        return Err(format!("wallet '{parent_id}' not found"));
+    }
+
+    // Default chain: the primary chain of the wallet's curve(s).
+    let has_secp = metas.iter().any(|m| m.curve_type == "secp256k1");
+    let chain = chain
+        .map(str::to_string)
+        .unwrap_or_else(|| if has_secp { "ethereum".into() } else { "solana".into() });
+    let path_s = starlab_core::accounts::standard_path(&chain, account)
+        .ok_or_else(|| format!("unknown chain {chain:?}"))?;
+    let curve = starlab_core::accounts::curve_for_chain(&chain)
+        .ok_or_else(|| format!("unknown chain {chain:?}"))?;
+    let meta = metas
+        .iter()
+        .find(|m| m.curve_type == curve)
+        .ok_or_else(|| format!("wallet '{parent_id}' has no {curve} share for {chain}"))?
+        .clone();
+
+    let child_id = format!("{parent_id}-{chain}-{account}");
+    if ks.get_wallet(&child_id).is_some() {
+        return Ok((child_id, false));
+    }
+
+    let parsed = starlab_core::DerivationPath::parse(&path_s)
+        .map_err(|e| format!("parse {path_s}: {e}"))?;
+    let blob = ks
+        .load_wallet_file_for_curve(parent_id, curve, password)
+        .map_err(|e| format!("unlock '{parent_id}' ({curve}): {e}"))?;
+    let (child_blob, child_group_hex) = match curve {
+        "ed25519" => derive_child_for_curve::<frost_ed25519::Ed25519Sha512>(&blob, &parsed)?,
+        _ => derive_child_for_curve::<frost_secp256k1::Secp256K1Sha256>(&blob, &parsed)?,
+    };
+    ks.create_wallet_multi_chain(
+        &child_id,
+        curve,
+        vec![],
+        meta.threshold,
+        meta.total_participants,
+        &child_group_hex,
+        &child_blob,
+        password,
+        vec![],
+        None,
+        meta.participant_index,
+        meta.participants.clone(),
+        Some(path_s),
+    )
+    .map_err(|e| format!("materialize account wallet: {e}"))?;
+    info!(
+        "materialized account wallet '{}' (deterministic — co-signers do the same on first use)",
+        child_id
+    );
+    Ok((child_id, true))
+}
+
+/// Unlock-time hook: if `wallet_id` is a well-formed HD account child id
+/// (`{parent}-{chain}-{account}`) that is MISSING locally but whose parent
+/// IS in the keystore, derive + persist it now — the caller has the
+/// password in hand, so a co-signer joining a signing session for a child
+/// it never derived "just works" instead of failing the wallet lookup.
+///
+/// Anything else is a no-op: ids that don't parse as a child, children
+/// already materialized, and child-shaped ids with an unknown parent all
+/// fall through to the existing (legacy) lookup/error path untouched.
+pub fn materialize_child_wallet_if_needed(
+    ks: &mut crate::keystore::Keystore,
+    wallet_id: &str,
+    password: &str,
+) -> Result<(), String> {
+    let Some((parent, chain, account)) =
+        starlab_core::accounts::parse_child_wallet_id(wallet_id)
+    else {
+        return Ok(());
+    };
+    if ks.get_wallet(wallet_id).is_some() || ks.get_wallet(parent).is_none() {
+        return Ok(());
+    }
+    let parent = parent.to_string();
+    let chain = chain.to_string();
+    ensure_account_wallet(ks, &parent, account, Some(&chain), password).map(|_| ())
+}
+
 /// Wire prefix for a unified round-1 package (mirrors `DKG_ROUND1:`). The
 /// payload after the colon is the `UnifiedRound1Package` JSON.
 pub(crate) const UNIFIED_DKG_ROUND1_PREFIX: &str = "UNIFIED_DKG_ROUND1:";
@@ -2343,7 +2481,7 @@ impl Command {
                 // `load_wallet_file` — the shared `Arc<Keystore>` is
                 // read-only and the load path doesn't need the live
                 // cache anyway.
-                let ks = match Keystore::new(&keystore_path, &device_id) {
+                let mut ks = match Keystore::new(&keystore_path, &device_id) {
                     Ok(ks) => ks,
                     Err(e) => {
                         let err = format!(
@@ -2355,6 +2493,24 @@ impl Command {
                         return Ok(());
                     }
                 };
+
+                // BIP-44 all the way: a signing announce may reference an HD
+                // account child (`{parent}-{chain}-{account}`) this device
+                // has never materialized. The password in hand unlocks the
+                // parent too, so derive + persist the child deterministically
+                // NOW instead of failing the lookup below. Non-child ids and
+                // unknown parents are a no-op (legacy path untouched).
+                if let Err(e) =
+                    materialize_child_wallet_if_needed(&mut ks, &wallet_id, &password)
+                {
+                    let err = format!(
+                        "UnlockWallet: materializing account wallet '{}' failed: {}",
+                        wallet_id, e
+                    );
+                    error!("{}", err);
+                    let _ = tx.send(Message::WalletUnlockFailed { error: err });
+                    return Ok(());
+                }
 
                 // `load_wallet_file` returns the decrypted blob bytes.
                 // Wrong-password / wrong-wallet_id errors bubble up as
@@ -3021,5 +3177,147 @@ mod tests {
     fn decode_keystore_blob_rejects_empty_input() {
         let result = decode_keystore_blob::<frost_secp256k1::Secp256K1Sha256>(&[]);
         assert!(result.is_err(), "empty input must fail");
+    }
+}
+
+/// Gap-1 coverage: a co-signer receiving a signing announce for an HD
+/// account child it never derived must materialize it at unlock time —
+/// and ONLY then. Everything else (root ids, unknown parents, children
+/// already present) must leave the keystore untouched so legacy signing
+/// flows behave exactly as before.
+#[cfg(test)]
+mod account_wallet_tests {
+    use super::*;
+    use frost_secp256k1::Secp256K1Sha256 as Secp;
+    use starlab_core::resharing::dkg_keypackages;
+
+    const PW: &str = "correct-horse-battery";
+    const PARENT: &str = "19caa3cf46d3";
+
+    /// Temp keystore holding one 2-of-3 secp256k1 parent wallet. Returns
+    /// the dir guard (keeps the files alive), the keystore, and the
+    /// parent's group public key hex.
+    fn keystore_with_parent() -> (tempfile::TempDir, crate::keystore::Keystore, String) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut ks = crate::keystore::Keystore::new(dir.path(), "device-1").expect("keystore");
+        let (kps, pp) = dkg_keypackages::<Secp>(3, 2, 17).expect("dkg");
+        let blob = encode_keystore_blob::<Secp>(&kps[&1], &pp).expect("encode");
+        let group_hex = hex::encode(pp.verifying_key().serialize().expect("group"));
+        ks.create_wallet_multi_chain(
+            PARENT,
+            "secp256k1",
+            vec![],
+            2,
+            3,
+            &group_hex,
+            &blob,
+            PW,
+            vec![],
+            None,
+            1,
+            vec!["alice".into(), "bob".into(), "carol".into()],
+            None,
+        )
+        .expect("create parent");
+        (dir, ks, group_hex)
+    }
+
+    /// (a) Join/unlock flow materializes a missing child when the parent
+    /// exists — with the EXACT id and path-label conventions, the parent's
+    /// session shape, and the SAME child group key public derivation
+    /// produces (so addresses shown by `wallet accounts` match the key
+    /// that will sign).
+    #[test]
+    fn materializes_missing_child_when_parent_exists() {
+        let (_dir, mut ks, parent_group) = keystore_with_parent();
+        let child_id = format!("{PARENT}-ethereum-7");
+
+        materialize_child_wallet_if_needed(&mut ks, &child_id, PW).expect("materialize");
+
+        let meta = ks.get_wallet(&child_id).expect("child must exist").clone();
+        assert_eq!(meta.label.as_deref(), Some("m/44'/60'/0'/0/7"), "label IS the path");
+        assert_eq!(meta.curve_type, "secp256k1");
+        assert_eq!((meta.threshold, meta.total_participants), (2, 3));
+        assert_eq!(meta.participant_index, 1);
+        assert_eq!(meta.participants, vec!["alice", "bob", "carol"]);
+
+        // The persisted child group key must equal the PUBLIC-only
+        // derivation every client's accounts table uses.
+        let path = starlab_core::DerivationPath::parse("m/44'/60'/0'/0/7").unwrap();
+        let expected = starlab_core::derive_child_verifying_key_path::<Secp>(
+            &hex::decode(&parent_group).unwrap(),
+            &path,
+        )
+        .unwrap();
+        assert_eq!(meta.group_public_key, hex::encode(expected));
+        assert_ne!(meta.group_public_key, parent_group, "child key must differ from root");
+
+        // And the encrypted share actually decodes for signing.
+        let blob = ks.load_wallet_file(&child_id, PW).expect("unlock child");
+        let (kp, pp) = decode_keystore_blob::<Secp>(&blob).expect("decode child");
+        assert_eq!(kp.verifying_key(), pp.verifying_key());
+    }
+
+    /// (b) Non-child ids and child-shaped ids with an unknown parent are
+    /// strict no-ops — the caller's legacy lookup/error path is preserved.
+    #[test]
+    fn unknown_and_non_child_ids_are_no_ops() {
+        let (_dir, mut ks, _) = keystore_with_parent();
+        for id in [
+            PARENT,                       // root id
+            "no-such-parent-ethereum-0",  // well-formed child, parent absent
+            "wallet-dogecoin-1",          // unknown chain
+            "wallet-ethereum-x",          // non-numeric account
+        ] {
+            materialize_child_wallet_if_needed(&mut ks, id, PW)
+                .unwrap_or_else(|e| panic!("{id} must be a no-op, got Err({e})"));
+        }
+        assert_eq!(ks.list_wallets().len(), 1, "nothing may be created");
+    }
+
+    /// (d) Re-join with the child already present skips materialization —
+    /// proven by passing a WRONG password, which would fail the parent
+    /// unlock if the code tried to derive again.
+    #[test]
+    fn already_present_child_skips_materialization() {
+        let (_dir, mut ks, _) = keystore_with_parent();
+        let child_id = format!("{PARENT}-ethereum-0");
+        let (id, materialized) =
+            ensure_account_wallet(&mut ks, PARENT, 0, Some("ethereum"), PW).expect("first");
+        assert_eq!(id, child_id);
+        assert!(materialized, "first call must materialize");
+
+        let (id, materialized) =
+            ensure_account_wallet(&mut ks, PARENT, 0, Some("ethereum"), PW).expect("second");
+        assert_eq!(id, child_id);
+        assert!(!materialized, "second call must find it");
+
+        materialize_child_wallet_if_needed(&mut ks, &child_id, "WRONG-password")
+            .expect("present child must short-circuit before any unlock");
+        assert_eq!(ks.list_wallets().len(), 2);
+    }
+
+    /// The default chain (no explicit `--chain`) is the primary chain of
+    /// the wallet's curve — ethereum for a secp256k1 share.
+    #[test]
+    fn default_chain_is_primary_for_curve() {
+        let (_dir, mut ks, _) = keystore_with_parent();
+        let (id, _) = ensure_account_wallet(&mut ks, PARENT, 3, None, PW).expect("ensure");
+        assert_eq!(id, format!("{PARENT}-ethereum-3"));
+    }
+
+    /// A wrong password surfaces the parent-unlock error instead of
+    /// silently writing garbage.
+    #[test]
+    fn wrong_password_fails_materialization() {
+        let (_dir, mut ks, _) = keystore_with_parent();
+        let err = materialize_child_wallet_if_needed(
+            &mut ks,
+            &format!("{PARENT}-ethereum-1"),
+            "WRONG-password",
+        )
+        .expect_err("must fail");
+        assert!(err.contains(PARENT), "error must name the parent: {err}");
+        assert!(ks.get_wallet(&format!("{PARENT}-ethereum-1")).is_none());
     }
 }

--- a/apps/tui/src/elm/update.rs
+++ b/apps/tui/src/elm/update.rs
@@ -447,6 +447,11 @@ pub fn update(model: &mut Model, msg: Message) -> Option<Command> {
             } else {
                 raw.clone()
             };
+            // "BIP-44 all the way": never sign with the root. A caller that
+            // passed a root id (e.g. the desktop's ElmSigningBackend) gets
+            // account 0 of the runner curve's primary chain; an explicit
+            // child id (the CLI one-shot always sends one) passes through.
+            let wallet_id = account_signing_wallet_id(&wallet_id, curve);
             model.wallet_state.pending_sign_message = Some(bytes_to_sign);
             model.wallet_state.pending_sign_wallet_id = Some(wallet_id);
             model.wallet_state.pending_sign_session_id = None;
@@ -1072,6 +1077,15 @@ pub fn update(model: &mut Model, msg: Message) -> Option<Command> {
                     }
                 },
             };
+
+            // "BIP-44 all the way": the UI navigates with the ROOT wallet id,
+            // but signing must use an ACCOUNT key — map to the account-0
+            // child of the runner curve's primary chain. (No per-account
+            // selection exists on the accounts table yet; when it does, the
+            // selected index slots in here.) The child share is materialized
+            // on demand at unlock time.
+            let wallet_id =
+                account_signing_wallet_id(&wallet_id, model.wallet_state.curve_type);
 
             let raw_message_bytes = model.wallet_state.sign_message_draft.as_bytes().to_vec();
             // For secp256k1 wallets, sign the EIP-191 hash of the message
@@ -3063,6 +3077,20 @@ fn short_session_id(id: &str) -> String {
 /// FROST will actually sign (EIP-191 hash for secp256k1, same as raw
 /// for ed25519), and the wallet's threshold so the user knows how
 /// many co-signers are being recruited.
+/// "BIP-44 all the way": signing must NEVER use the root key. Map a root
+/// wallet id to its account-0 child for the runner curve's primary chain
+/// (ethereum for secp256k1, solana for ed25519); ids that already name an
+/// account child (`{parent}-{chain}-{account}`) pass through unchanged.
+/// The child share is materialized on demand at unlock time (the user has
+/// just typed the password) by `Command::UnlockWallet`.
+fn account_signing_wallet_id(wallet_id: &str, curve_type: &str) -> String {
+    if starlab_core::accounts::parse_child_wallet_id(wallet_id).is_some() {
+        return wallet_id.to_string();
+    }
+    let chain = if curve_type == "secp256k1" { "ethereum" } else { "solana" };
+    format!("{wallet_id}-{chain}-0")
+}
+
 fn preview_lines(
     wallet_id: &str,
     curve: &str,
@@ -3070,11 +3098,25 @@ fn preview_lines(
     raw_message: Option<&[u8]>,
     wallets: &[crate::keystore::WalletMetadata],
 ) -> String {
+    // An account child id won't be in the (root-only) wallet list — fall
+    // back to its parent for the threshold metadata, and surface the
+    // BIP-44 identity ("signing as") so the user sees the account key,
+    // not the root.
+    let child = starlab_core::accounts::parse_child_wallet_id(wallet_id);
     let (threshold, total) = wallets
         .iter()
-        .find(|w| w.session_id == wallet_id)
+        .find(|w| {
+            w.session_id == wallet_id
+                || child.is_some_and(|(parent, _, _)| w.session_id == parent)
+        })
         .map(|w| (w.threshold, w.total_participants))
         .unwrap_or((0, 0));
+    let account_line = child
+        .and_then(|(_, chain, account)| {
+            starlab_core::accounts::standard_path(chain, account)
+                .map(|path| format!("Account: {} ({})", account, path))
+        })
+        .unwrap_or_default();
 
     let user_message_line = match raw_message {
         Some(bytes) => match std::str::from_utf8(bytes) {
@@ -3112,8 +3154,11 @@ fn preview_lines(
         String::new()
     };
 
-    let mut lines: Vec<String> = Vec::with_capacity(7);
+    let mut lines: Vec<String> = Vec::with_capacity(8);
     lines.push(format!("Wallet: {}", wallet_id));
+    if !account_line.is_empty() {
+        lines.push(account_line);
+    }
     if !threshold_line.is_empty() {
         lines.push(threshold_line);
     }
@@ -3287,6 +3332,7 @@ mod tests {
     #[test]
     fn headless_sign_seeds_pending_state_and_hands_off() {
         let mut model = Model::new("dev".to_string());
+        model.wallet_state.curve_type = "secp256k1";
         let cmd = update(
             &mut model,
             Message::HeadlessSign {
@@ -3297,9 +3343,11 @@ mod tests {
             },
         );
         assert!(model.wallet_state.pending_sign_message.is_some());
+        // "BIP-44 all the way": a root id is mapped to its account-0 child
+        // for the runner curve's primary chain — never the root key.
         assert_eq!(
             model.wallet_state.pending_sign_wallet_id.as_deref(),
-            Some("wallet-ab12")
+            Some("wallet-ab12-ethereum-0")
         );
         assert!(model.wallet_state.pending_sign_session_id.is_none());
         match cmd {
@@ -3447,5 +3495,131 @@ mod tests {
             model.current_screen,
             Screen::WalletDetail { ref wallet_id } if wallet_id == "w1"
         ));
+    }
+
+    // ----- "BIP-44 all the way" signing-identity tests (Gap 2) -----
+    //
+    // Signing must NEVER use the root key: every initiation path maps a
+    // root wallet id to its account-0 child; explicit child ids pass
+    // through. (The co-signer-side on-demand materialization — Gap 1 —
+    // is keystore IO and lives in `command::account_wallet_tests`.)
+
+    #[test]
+    fn account_signing_wallet_id_maps_root_to_account0_child() {
+        assert_eq!(account_signing_wallet_id("19caa3cf46d3", "secp256k1"), "19caa3cf46d3-ethereum-0");
+        assert_eq!(account_signing_wallet_id("19caa3cf46d3", "ed25519"), "19caa3cf46d3-solana-0");
+        // Already-a-child ids pass through untouched, any chain/account.
+        assert_eq!(account_signing_wallet_id("19caa3cf46d3-bitcoin-7", "secp256k1"), "19caa3cf46d3-bitcoin-7");
+        assert_eq!(account_signing_wallet_id("19caa3cf46d3-sui-2", "ed25519"), "19caa3cf46d3-sui-2");
+    }
+
+    /// (c) TUI-initiated signing (SignTransaction → SignSubmit → Confirm →
+    /// SubmitPassword) carries the account-0 CHILD id end-to-end: through
+    /// the preview, the pending stash, and the UnlockWallet dispatch (where
+    /// the child share is materialized on demand).
+    #[test]
+    fn tui_sign_initiation_uses_account0_child_id() {
+        let mut model = Model::new("test".to_string());
+        model.wallet_state.curve_type = "secp256k1";
+        model.current_screen = Screen::SignTransaction { wallet_id: "19caa3cf46d3".to_string() };
+        model.wallet_state.sign_message_draft = "hello".to_string();
+
+        update(&mut model, Message::SignSubmit);
+        let preview = model
+            .wallet_state
+            .pending_sign_preview
+            .as_ref()
+            .expect("SignSubmit must stash a preview");
+        assert_eq!(preview.wallet_id, "19caa3cf46d3-ethereum-0", "preview signs as the child");
+        // The "signing as" identity shown to the user is the child + path.
+        match &model.ui_state.modal {
+            Some(Modal::Confirm { message, .. }) => {
+                assert!(message.contains("19caa3cf46d3-ethereum-0"), "{message}");
+                assert!(message.contains("m/44'/60'/0'/0/0"), "{message}");
+            }
+            other => panic!("expected confirm modal, got {:?}", other.is_some()),
+        }
+
+        update(&mut model, Message::ConfirmSigningRequest);
+        assert_eq!(
+            model.wallet_state.pending_sign_wallet_id.as_deref(),
+            Some("19caa3cf46d3-ethereum-0"),
+            "cold path must stash the child id"
+        );
+
+        let cmd = update(&mut model, Message::SubmitPassword { value: "pw".to_string() });
+        match cmd {
+            Some(Command::UnlockWallet { wallet_id, .. }) => {
+                assert_eq!(wallet_id, "19caa3cf46d3-ethereum-0")
+            }
+            other => panic!("expected UnlockWallet, got {:?}", other.is_some()),
+        }
+    }
+
+    /// HeadlessSign (CLI one-shot / desktop ElmSigningBackend entry): a
+    /// root id is mapped to the runner curve's account-0 child; an
+    /// explicit child id is honored as-is.
+    #[test]
+    fn headless_sign_maps_root_to_child_and_keeps_explicit_child() {
+        let mut model = Model::new("test".to_string());
+        model.wallet_state.curve_type = "ed25519";
+        update(&mut model, Message::HeadlessSign {
+            wallet_id: "rootabc".to_string(),
+            message: "m".to_string(),
+            encoding: "utf8".to_string(),
+            password: "pw".to_string(),
+        });
+        assert_eq!(
+            model.wallet_state.pending_sign_wallet_id.as_deref(),
+            Some("rootabc-solana-0")
+        );
+
+        let mut model = Model::new("test".to_string());
+        model.wallet_state.curve_type = "secp256k1";
+        update(&mut model, Message::HeadlessSign {
+            wallet_id: "rootabc-ethereum-7".to_string(),
+            message: "m".to_string(),
+            encoding: "utf8".to_string(),
+            password: "pw".to_string(),
+        });
+        assert_eq!(
+            model.wallet_state.pending_sign_wallet_id.as_deref(),
+            Some("rootabc-ethereum-7")
+        );
+    }
+
+    /// Joiner/co-signer path: a signing announce naming a CHILD wallet id
+    /// flows into UnlockWallet with that exact id (the executor then
+    /// materializes it if missing — Gap 1). A root-id announce from an old
+    /// peer takes the identical path untouched (legacy compat).
+    #[test]
+    fn joiner_unlock_uses_announced_wallet_id_verbatim() {
+        for announced in ["19caa3cf46d3-ethereum-7", "legacy-root-wallet"] {
+            let mut model = Model::new("test".to_string());
+            model.active_session = Some(SessionInfo {
+                session_id: "sess1".to_string(),
+                proposer_id: "peer".to_string(),
+                total: 3,
+                threshold: 2,
+                participants: vec!["peer".to_string(), "test".to_string()],
+                session_type: SessionType::Signing {
+                    wallet_name: announced.to_string(),
+                    curve_type: "secp256k1".to_string(),
+                    blockchain: "ethereum".to_string(),
+                    group_public_key: String::new(),
+                },
+                curve_type: "secp256k1".to_string(),
+                coordination_type: "online".to_string(),
+                signing_message_hex: Some(hex::encode(b"msg")),
+            });
+
+            let cmd = update(&mut model, Message::SubmitPassword { value: "pw".to_string() });
+            match cmd {
+                Some(Command::UnlockWallet { wallet_id, .. }) => assert_eq!(wallet_id, announced),
+                other => panic!("expected UnlockWallet, got {:?}", other.is_some()),
+            }
+            assert_eq!(model.wallet_state.pending_sign_wallet_id.as_deref(), Some(announced));
+            assert_eq!(model.wallet_state.pending_sign_session_id.as_deref(), Some("sess1"));
+        }
     }
 }

--- a/apps/tui/tests/update_transitions.rs
+++ b/apps/tui/tests/update_transitions.rs
@@ -803,7 +803,9 @@ fn sign_submit_dispatches_initiate_signing_and_clears_draft() {
         wallet_id: "wallet-test".to_string(),
     };
     model.wallet_state.curve_type = "secp256k1";
-    model.wallet_state.wallet_unlocked_id = Some("wallet-test".to_string());
+    // "BIP-44 all the way": signing uses the account-0 CHILD of the root
+    // id, so the warm marker carries the child id too.
+    model.wallet_state.wallet_unlocked_id = Some("wallet-test-ethereum-0".to_string());
     for c in "Sign this".chars() {
         update(&mut model, Message::SignTypeChar(c));
     }
@@ -823,7 +825,7 @@ fn sign_submit_dispatches_initiate_signing_and_clears_draft() {
         .as_ref()
         .expect("preview must be stashed for ConfirmSigningRequest");
     assert!(preview.warm, "warm path must be flagged");
-    assert_eq!(preview.wallet_id, "wallet-test");
+    assert_eq!(preview.wallet_id, "wallet-test-ethereum-0");
     assert_eq!(
         preview.bytes_to_sign,
         starlab_client::utils::eth_helper::eip191_hash(b"Sign this"),
@@ -834,7 +836,7 @@ fn sign_submit_dispatches_initiate_signing_and_clears_draft() {
     let cmd = update(&mut model, Message::ConfirmSigningRequest);
     match cmd {
         Some(Command::SendMessage(Message::InitiateSigning { request })) => {
-            assert_eq!(request.wallet_id, "wallet-test");
+            assert_eq!(request.wallet_id, "wallet-test-ethereum-0");
             assert_eq!(request.chain, "secp256k1");
             assert_eq!(
                 request.transaction_data,
@@ -1075,7 +1077,8 @@ fn sign_submit_when_wallet_unlocked_dispatches_initiate_signing_directly() {
     model.current_screen = Screen::SignTransaction {
         wallet_id: "w-warm".to_string(),
     };
-    model.wallet_state.wallet_unlocked_id = Some("w-warm".to_string());
+    // Warm marker is the account-0 child — that's the id signing uses.
+    model.wallet_state.wallet_unlocked_id = Some("w-warm-ethereum-0".to_string());
     model.wallet_state.curve_type = "secp256k1";
     for c in "hi".chars() {
         update(&mut model, Message::SignTypeChar(c));
@@ -1089,7 +1092,7 @@ fn sign_submit_when_wallet_unlocked_dispatches_initiate_signing_directly() {
     let cmd = update(&mut model, Message::ConfirmSigningRequest);
     match cmd {
         Some(Command::SendMessage(Message::InitiateSigning { request })) => {
-            assert_eq!(request.wallet_id, "w-warm");
+            assert_eq!(request.wallet_id, "w-warm-ethereum-0");
             // secp256k1 → transaction_data is the EIP-191 hash.
             assert_eq!(
                 request.transaction_data,
@@ -1155,7 +1158,9 @@ fn sign_submit_when_wallet_not_unlocked_routes_to_password_prompt() {
     );
     assert_eq!(
         model.wallet_state.pending_sign_wallet_id.as_deref(),
-        Some("w-cold"),
+        // Non-secp curve in this fixture → the primary chain is solana.
+        Some("w-cold-solana-0"),
+        "cold path stashes the account-0 child, never the root",
     );
     assert!(
         model.wallet_state.pending_sign_session_id.is_none(),
@@ -2687,7 +2692,7 @@ fn double_confirm_signing_request_is_a_safe_noop() {
         wallet_id: "w2".to_string(),
     };
     model.wallet_state.curve_type = "secp256k1";
-    model.wallet_state.wallet_unlocked_id = Some("w2".to_string());
+    model.wallet_state.wallet_unlocked_id = Some("w2-ethereum-0".to_string());
     for c in "once".chars() {
         update(&mut model, Message::SignTypeChar(c));
     }

--- a/packages/@starlab/core/src/accounts.rs
+++ b/packages/@starlab/core/src/accounts.rs
@@ -24,6 +24,41 @@ pub fn chains_for_curve(curve: &str) -> &'static [(&'static str, &'static str)] 
     }
 }
 
+/// The curve whose key share signs for a chain. Inverse of
+/// [`chains_for_curve`]; accepts the same aliases as [`standard_path`].
+pub fn curve_for_chain(chain: &str) -> Option<&'static str> {
+    match chain.to_ascii_lowercase().as_str() {
+        "ethereum" | "eth" | "bitcoin" | "btc" => Some("secp256k1"),
+        "solana" | "sol" | "sui" => Some("ed25519"),
+        _ => None,
+    }
+}
+
+/// Parse an HD account child wallet id of the canonical form
+/// `{parent}-{chain}-{account}` (e.g. `19caa3cf46d3-ethereum-7`) into
+/// `(parent, chain, account)`.
+///
+/// This is THE convention every client uses to name materialized account
+/// wallets, so a co-signer that receives a signing announce for a child it
+/// has never derived can recognize it and materialize it deterministically.
+/// Returns `None` for anything that isn't a well-formed child id — root
+/// ids, arbitrary hyphenated names, unknown chains — so callers can leave
+/// those on their existing path untouched.
+pub fn parse_child_wallet_id(id: &str) -> Option<(&str, &str, u32)> {
+    let (rest, account_s) = id.rsplit_once('-')?;
+    // Strict digits only: `u32::parse` would also accept "+7", which no
+    // client ever emits — reject it so odd root ids can't be misread.
+    if account_s.is_empty() || !account_s.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let account = account_s.parse::<u32>().ok()?;
+    let (parent, chain) = rest.rsplit_once('-')?;
+    if parent.is_empty() || curve_for_chain(chain).is_none() {
+        return None;
+    }
+    Some((parent, chain, account))
+}
+
 /// The PINNED standard derivation path per chain (BIP-44/84 coin types).
 pub fn standard_path(chain: &str, account: u32) -> Option<String> {
     match chain.to_ascii_lowercase().as_str() {
@@ -162,6 +197,40 @@ mod tests {
         assert_eq!(standard_path("solana", 2).unwrap(), "m/44'/501'/2'/0'");
         assert_eq!(standard_path("sui", 3).unwrap(), "m/44'/784'/3'/0'/0'");
         assert!(standard_path("dogecoin", 0).is_none());
+    }
+
+    #[test]
+    fn parse_child_wallet_id_round_trips_the_canonical_form() {
+        assert_eq!(
+            parse_child_wallet_id("19caa3cf46d3-ethereum-7"),
+            Some(("19caa3cf46d3", "ethereum", 7))
+        );
+        assert_eq!(
+            parse_child_wallet_id("abc-def-solana-0"),
+            Some(("abc-def", "solana", 0))
+        );
+    }
+
+    #[test]
+    fn parse_child_wallet_id_rejects_non_child_ids() {
+        // Root ids, unknown chains, non-numeric accounts, junk.
+        assert_eq!(parse_child_wallet_id("19caa3cf46d3"), None);
+        assert_eq!(parse_child_wallet_id("wallet-dogecoin-1"), None);
+        assert_eq!(parse_child_wallet_id("wallet-ethereum-x"), None);
+        assert_eq!(parse_child_wallet_id("wallet-ethereum-+7"), None);
+        assert_eq!(parse_child_wallet_id("-ethereum-1"), None);
+        assert_eq!(parse_child_wallet_id("ethereum-1"), None);
+        assert_eq!(parse_child_wallet_id(""), None);
+    }
+
+    #[test]
+    fn curve_for_chain_matches_chains_for_curve() {
+        for curve in ["secp256k1", "ed25519"] {
+            for (key, _) in chains_for_curve(curve) {
+                assert_eq!(curve_for_chain(key), Some(curve), "{key}");
+            }
+        }
+        assert_eq!(curve_for_chain("dogecoin"), None);
     }
 
     #[test]


### PR DESCRIPTION
Closes the two gaps found in today's live 2-of-3 account-7 signing test (which needed a manual `wallet derive --save` on the co-signer):

## Gap 1 — co-signers auto-materialize account children
`Command::UnlockWallet` (shared elm executor — covers CLI `serve`, the TUI approval modal, AND desktop via ElmSigningBackend) now calls `materialize_child_wallet_if_needed` before the keystore lookup: announced id parses as `{parent}-{chain}-{account}`, parent present, child absent → derive + save the child (parent's threshold/participants/index, label = derivation path). Non-child ids / unknown parents / present children are strict no-ops — legacy root-id announces behave exactly as before.

## Gap 2 — TUI sign-initiation never uses the root
`account_signing_wallet_id()` applied in `SignSubmit` and `HeadlessSign`: root id → account-0 child of the runner curve's primary chain (ethereum for secp256k1, solana for ed25519); explicit child ids pass through. Confirm modal shows the child identity + `Account: N (m/44'/...)`.

## One implementation, three layers
- `starlab_core::accounts::parse_child_wallet_id` (strict: digits-only account, chain validated against the pinned table — the old CLI heuristic misread any `a-b-7` as a child) + `curve_for_chain`
- `ensure_account_wallet` / `derive_child_for_curve` lifted from the CLI into `starlab-client` elm::command; CLI oneshot is now a thin shim

Tests: workspace fully green (321 pass / 0 fail) — new real-FROST tempfile-keystore materialization tests (derive, no-op variants, wrong-password, child group key == public-only derivation) + elm flow tests (SignSubmit→Confirm→SubmitPassword carries the child id end-to-end; joiner passes announced ids verbatim). No wire/protocol changes.

Behavior note: a `HeadlessSign` with a root id (old desktop behavior) now signs as account 0 instead of the root key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)